### PR TITLE
docs: add quickstart menu

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ The latest versions of this document can be found from sites below:
    :maxdepth: 2
    :caption: Table of Contents
 
+   quickstart
    disclaimer
    overview/overview
    installation/installation

--- a/docs/locale/ko/LC_MESSAGES/quickstart.po
+++ b/docs/locale/ko/LC_MESSAGES/quickstart.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Backend.AI Web-UI User Guide 22.09\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-09 14:18+0900\n"
+"POT-Creation-Date: 2023-03-09 14:40+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,15 +26,15 @@ msgid ""
 "Welcome to Quickstart guide of Backend.AI WebUI. This tutorial will cover"
 " the essentials of using Backend.AI without any knowledge base."
 msgstr ""
-"Backend.AI WebUI를 사용하는 빠른시작 가이드입니다. 이 튜토리얼에서는 다른 지식기반이 없이도 "
-"Backend.AI 를 사용할 수 있도록 꼭 필요한 내용만을 다룹니다."
+"Backend.AI WebUI를 사용하는 빠른시작 가이드입니다. 이 튜토리얼에서는 다른 지식기반이 없이도 Backend.AI 를 "
+"사용할 수 있도록 꼭 필요한 내용만을 다룹니다."
 
 #: ../../quickstart.rst:10
 msgid "Objectives"
 msgstr "목표"
 
 #: ../../quickstart.rst:13
-msgid "Part 1. Basic guide of using Backend.AI"
+msgid "Part 1. Basic guide to using Backend.AI"
 msgstr "파트 1. Backend.AI 기초 사용 가이드"
 
 #: ../../quickstart.rst:14
@@ -54,7 +54,7 @@ msgid ":ref:`How to delete a session<delete_session>`"
 msgstr ":ref:`세션 종료하는 방법<delete_session>` "
 
 #: ../../quickstart.rst:20
-msgid "Part 2. Advanced guide of using Backend.AI"
+msgid "Part 2. Advanced guide to using Backend.AI"
 msgstr "파트 2. Backend.AI 고급 사용 가이드"
 
 #: ../../quickstart.rst:21

--- a/docs/locale/ko/LC_MESSAGES/quickstart.po
+++ b/docs/locale/ko/LC_MESSAGES/quickstart.po
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2022, Lablup Inc.
+# This file is distributed under the same license as the Backend.AI Web-UI
+# User Guide package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Backend.AI Web-UI User Guide 22.09\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-03-09 14:18+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: ../../quickstart.rst:2
+msgid "Quickstart"
+msgstr "빠른 시작"
+
+#: ../../quickstart.rst:4
+msgid ""
+"Welcome to Quickstart guide of Backend.AI WebUI. This tutorial will cover"
+" the essentials of using Backend.AI without any knowledge base."
+msgstr ""
+"Backend.AI WebUI를 사용하는 빠른시작 가이드입니다. 이 튜토리얼에서는 다른 지식기반이 없이도 "
+"Backend.AI 를 사용할 수 있도록 꼭 필요한 내용만을 다룹니다."
+
+#: ../../quickstart.rst:10
+msgid "Objectives"
+msgstr "목표"
+
+#: ../../quickstart.rst:13
+msgid "Part 1. Basic guide of using Backend.AI"
+msgstr "파트 1. Backend.AI 기초 사용 가이드"
+
+#: ../../quickstart.rst:14
+msgid ":ref:`How to create a virtual folder<create_storage_folder>`"
+msgstr ":ref:`가상 폴더 만드는 방법<create_storage_folder>` "
+
+#: ../../quickstart.rst:15
+msgid ":ref:`How to create a session<create_session>`"
+msgstr ":ref:`세션 생성하는 방법<create_session>` "
+
+#: ../../quickstart.rst:16
+msgid ":ref:`How to use a session<use_session>`"
+msgstr ":ref:`세션 사용하는 방법<use_session>` "
+
+#: ../../quickstart.rst:17
+msgid ":ref:`How to delete a session<delete_session>`"
+msgstr ":ref:`세션 종료하는 방법<delete_session>` "
+
+#: ../../quickstart.rst:20
+msgid "Part 2. Advanced guide of using Backend.AI"
+msgstr "파트 2. Backend.AI 고급 사용 가이드"
+
+#: ../../quickstart.rst:21
+msgid ":ref:`How to use terminal application with tmux<tmux_guide>`"
+msgstr ":ref:`tmux 를 사용한 terminal 사용법<tmux_guide>` "
+
+#: ../../quickstart.rst:22
+msgid ""
+":ref:`How to install extra pip package using automount virtual "
+"folder<install_pip_pkg>`"
+msgstr ":ref:`자동마운트되는 가상폴더를 사용해서 pip 패키지를 설치하는 방법<install_pip_pkg>` "
+
+#: ../../quickstart.rst:23
+msgid ":ref:`How to use SSH/sFTP using desktop application<ssh-sftp-container>`"
+msgstr ":ref:`데스크톱 애플리케이션으로 SSH/sFTP 을 사용하는 방법<ssh-sftp-container>` "
+
+#: ../../quickstart.rst:24
+msgid ":ref:`How to install apt packages<installing_apt_pkg>`"
+msgstr ":ref:`APT 패키지 설치하는 방법<installing_apt_pkg>` "
+

--- a/docs/locale/ko/LC_MESSAGES/quickstart.po
+++ b/docs/locale/ko/LC_MESSAGES/quickstart.po
@@ -26,7 +26,7 @@ msgid ""
 "Welcome to Quickstart guide of Backend.AI WebUI. This tutorial will cover"
 " the essentials of using Backend.AI without any knowledge base."
 msgstr ""
-"Backend.AI WebUI를 사용하는 빠른시작 가이드입니다. 이 튜토리얼에서는 다른 지식기반이 없이도 Backend.AI 를 "
+"Backend.AI WebUI를 사용하는 빠른 시작 가이드입니다. 이 튜토리얼에서는 다른 지식기반이 없이도 Backend.AI 를 "
 "사용할 수 있도록 꼭 필요한 내용만을 다룹니다."
 
 #: ../../quickstart.rst:10

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,14 +9,14 @@ knowledge base.
 Objectives
 ------------
 
-Part 1. Basic guide of using Backend.AI
+Part 1. Basic guide to using Backend.AI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - :ref:`How to create a virtual folder<create_storage_folder>`
 - :ref:`How to create a session<create_session>`
 - :ref:`How to use a session<use_session>`
 - :ref:`How to delete a session<delete_session>`
 
-Part 2. Advanced guide of using Backend.AI
+Part 2. Advanced guide to using Backend.AI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - :ref:`How to use terminal application with tmux<tmux_guide>`
 - :ref:`How to install extra pip package using automount virtual folder<install_pip_pkg>`

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,24 @@
+Quickstart
+==============
+
+Welcome to Quickstart guide of Backend.AI WebUI. 
+This tutorial will cover the essentials of using Backend.AI without any 
+knowledge base.   
+
+
+Objectives
+------------
+
+Part 1. Basic guide of using Backend.AI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- :ref:`How to create a virtual folder<create_storage_folder>`
+- :ref:`How to create a session<create_session>`
+- :ref:`How to use a session<use_session>`
+- :ref:`How to delete a session<delete_session>`
+
+Part 2. Advanced guide of using Backend.AI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- :ref:`How to use terminal application with tmux<tmux_guide>`
+- :ref:`How to install extra pip package using automount virtual folder<install_pip_pkg>`
+- :ref:`How to use SSH/sFTP using desktop application<ssh-sftp-container>`
+- :ref:`How to install apt packages<installing_apt_pkg>`

--- a/docs/sessions_all/sessions_all.rst
+++ b/docs/sessions_all/sessions_all.rst
@@ -7,6 +7,8 @@ Data & Storage pages. Here, you will learn how to query and
 create container-based compute sessions and utilize various web applications on
 the Sessions page.
 
+.. _create_session:
+
 Start a new session
 -------------------
 
@@ -226,6 +228,8 @@ accessible resources.
    utilize SM (streaming multiprocessor) and GPU memory corresponding to 0.2
    physical GPU for the session.
 
+.. _use_session:
+
 
 Use Jupyter Notebook
 ----------------------
@@ -343,6 +347,8 @@ The new session name should also follow the :ref:`the authoring rule<session-nam
 .. image:: session_renaming.png
 
 
+.. _delete_session:
+
 Delete a compute session
 ------------------------
 
@@ -405,8 +411,10 @@ If you want to delete the whole variables and value, please click DELETE ALL but
 Save container commit
 ---------------------
 
-From 22.09, Backend.AI now support container commit feature. Since one or more sessions correspond to spawned container when executed,
-container commit will save all information stored in sessions. When you click the download button in control pane of ``RUNNING`` session, 
+From 22.09, Backend.AI now support container commit feature.
+Since one or more sessions correspond to spawned container when executed,
+container commit will save all information stored in sessions. 
+When you click the download button in control pane of ``RUNNING`` session, 
 you can see the information of container, corresponds to the selected row(session).
 
 .. image:: container_commit.png
@@ -443,6 +451,8 @@ To resolve this issue, setting the number of threads to 1 or 2 would work.
    :align: center
    :alt: Session HPC Optimization
 
+
+.. _tmux_guide:
 
 Advanced web terminal usage
 ---------------------------

--- a/docs/trouble_shooting/trouble_shooting.rst
+++ b/docs/trouble_shooting/trouble_shooting.rst
@@ -25,6 +25,8 @@ If there are problems in recognizing authentication cookies, users may not be ab
 to login with private browser window. If it succeeds, please clear your
 browser's cache and/or application data.
 
+.. _installing_apt_pkg:
+
 How to install apt packages?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -55,6 +57,9 @@ Now, you can install packages by ``brew``:
 folder named ``.linuxbrew``, which will be automatically mounted when creating a
 compute session, those installed packages can be kept after compute session is
 destroyed and then reused for the next compute session.
+
+
+.. _install_pip_pkg:
 
 How to install packages with pip?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/vfolder/vfolder.rst
+++ b/docs/vfolder/vfolder.rst
@@ -39,6 +39,8 @@ Check marks on the Owner panel in the folder list indicate the user created fold
    search boxes on top of the list.
 
 
+.. _create_storage_folder:
+
 Create storage folder
 ---------------------
 


### PR DESCRIPTION
## Description
> NOTE: This issue is suggested by @adrysn.

This PR adds a quickstart menu which will make user more easily use Backend.AI at a glance.
I split features into two parts (basic/advanced) so that users can notice the guide with their own purpose.
Both Part 1 and Part 2 are mostly related to "session", but Part 2 contains more detailed usage guides.

- Part 1. Basic guide to using Backend.AI
   - How to create a virtual folder
   - How to create a session
   - How to use a session
   - How to delete a session
- Part 2. Advanced guide to using Backend.AI
   - How to use terminal application with tmux
   - How to install extra pip package using automount virtual folder
   -  How to use SSH/sFTP using desktop application
   -  How to install apt packages