### PR TITLE
docs: resize font-size of ads

### DIFF
--- a/docs/_static/css/customTheme.css
+++ b/docs/_static/css/customTheme.css
@@ -7567,6 +7567,6 @@ span.linenos.special { color: #767676; background-color: #ffffc0; padding-left: 
 .highlight .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */
 
 /* DO NOT REMOVE THIS - customizing ads comment in ethical ads */
-.ethical-rtd .ethical-sidebar, a {
+div.ethical-callout > * > * > a {
   font-size: small;
 }

--- a/docs/_static/css/customTheme.css
+++ b/docs/_static/css/customTheme.css
@@ -7565,3 +7565,8 @@ span.linenos.special { color: #767676; background-color: #ffffc0; padding-left: 
 .highlight .vi { color: #767676 } /* Name.Variable.Instance */
 .highlight .vm { color: #767676 } /* Name.Variable.Magic */
 .highlight .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */
+
+/* DO NOT REMOVE THIS - customizing ads comment in ethical ads */
+.ethical-rtd .ethical-sidebar, a {
+  font-size: small;
+}


### PR DESCRIPTION
This PR resolves cosmetic issue due to unexpected font-size in ethical ads by resizing into a `small` size with css customization.

| after | before |
|------|--------|
| <img width="289" alt="Screenshot 2024-03-26 at 12 22 46 PM" src="https://github.com/lablup/backend.ai-docs-2023/assets/46954439/9e7ab374-1aa3-4560-822e-3d4b88b78038"> | <img width="293" alt="Screenshot 2024-03-26 at 12 23 06 PM" src="https://github.com/lablup/backend.ai-docs-2023/assets/46954439/484794fe-e46e-43e5-bde4-3b0e36b3a26a"> |
