### PR TITLE
docs: add offline download on page

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,7 @@ sphinx:
 python:
   install:
   - requirements: docs/requirements.txt
+
+formats:
+  - epub
+  - pdf


### PR DESCRIPTION
This PR applies downloadable material(e.g. pdf, epub, htmlzip...) on published pages