### PR TITLE
Docs/update readthedocs yaml and config with font

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,9 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: html
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ latex_elements = {
         \setsanshangulfont{Pretendard}
         \setmainfont{Pretendard}
         \setsansfont{Pretendard}
-        \setmonofont{Pretendard}
+        \setmonofont{JetBrains Mono}
 
         \setcounter{chapter}{-1}
         \doublespacing


### PR DESCRIPTION
This PR updates
- readthedocs yaml file with detailed builder config
- monospace font from Pretendard to JetBrains Mono