### PR TITLE
fix: unexpected indent error in model serving doc

### DIFF
--- a/docs/model_serving/model_serving.rst
+++ b/docs/model_serving/model_serving.rst
@@ -224,7 +224,7 @@ First, provide a service name. For detailed explanations of each item, please re
       :alt: Runtime Variant
 
    For example, if you choose ``vLLM`` or ``NVIDIA NIM`` or ``Predefined Image Command`` as a runtime variant of model service,
-    there's no need to configure a ``model-definition`` file in your model folder to mount. Instead, you might have to set an additional environment variable.
+   there's no need to configure a ``model-definition`` file in your model folder to mount. Instead, you might have to set an additional environment variable.
    For more information, please take a look at
    `Model Variant: Easily Serving Various Model Services <https://www.backend.ai/blog/2024-07-10-various-ways-of-model-serving>`_.
 


### PR DESCRIPTION
Fixed indentation in model serving doc which raises:
```bash
docs/model_serving/model_serving.rst:228: WARNING: Definition list ends without a blank line; unexpected unindent.
```