### PR TITLE
fix: Use lowercase png ext for signup dialog image

### DIFF
--- a/docs/login/login.rst
+++ b/docs/login/login.rst
@@ -20,7 +20,7 @@ be sent to verify that the email is yours. If the verification email is sent, yo
 will need to read the email and click the link inside to pass verification
 before you can log in with your account.
 
-.. image:: signup_dialog.PNG
+.. image:: signup_dialog.png
    :width: 350
    :align: center
    :alt: Signup dialog
@@ -89,10 +89,10 @@ administrator.
 
 
 Sidebar Menus
--------------------- 
+--------------------
 
-Change the size of the sidebar via the buttons on the right side of the sidebar. 
-Click it to significantly reduce the width of the sidebar, giving you a wider view of its contents. 
+Change the size of the sidebar via the buttons on the right side of the sidebar.
+Click it to significantly reduce the width of the sidebar, giving you a wider view of its contents.
 Clicking it again will return the sidebar to its original width.
 
 
@@ -102,22 +102,22 @@ Clicking it again will return the sidebar to its original width.
 
 Header Events
 ----------------
-The bell shape button is the event notification button. 
-Events that need to be recorded during Web-UI operation are displayed here. 
-When background tasks are running, such as creating a compute session, 
-you can check the jobs here. When the background task is finished. 
+The bell shape button is the event notification button.
+Events that need to be recorded during Web-UI operation are displayed here.
+When background tasks are running, such as creating a compute session,
+you can check the jobs here. When the background task is finished.
 
 .. image:: notification.png
    :align: center
    :width: 600
 
-You can change the theme mode of the Web-UI via the dark mode icon on the 
-right side of the header. 
+You can change the theme mode of the Web-UI via the dark mode icon on the
+right side of the header.
 
 .. image:: theme_mode.png
    :align: center
    :width: 800
 
 
-There is a question mark icon at the lower right side of the header. 
+There is a question mark icon at the lower right side of the header.
 Click this icon to access the web version of this guide document.


### PR DESCRIPTION
- Changed the file extension of `signup_dialog.PNG` to `signup_dialog.png` to suppress readthedocs build warning.