### PR TITLE
docs(FR-746): update version numbers to 25.05

### DIFF
--- a/docs/locale/ko/LC_MESSAGES/admin_menu/admin_menu.po
+++ b/docs/locale/ko/LC_MESSAGES/admin_menu/admin_menu.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-10 16:26+0900\n"
 "PO-Revision-Date: 2022-05-17 22:53+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/admin_user_keypair_management/admin_user_keypair_management.po
+++ b/docs/locale/ko/LC_MESSAGES/admin_user_keypair_management/admin_user_keypair_management.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-12-23 15:47+0900\n"
 "PO-Revision-Date: 2020-12-23 15:48+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/agent_summary/agent_summary.po
+++ b/docs/locale/ko/LC_MESSAGES/agent_summary/agent_summary.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2022, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Web-UI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Web-UI User Guide 23.03\n"
+"Project-Id-Version: Backend.AI Web-UI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-14 11:59+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/appendix/allocate_gpu.po
+++ b/docs/locale/ko/LC_MESSAGES/appendix/allocate_gpu.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.03\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-12-23 13:53+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/appendix/appendix.po
+++ b/docs/locale/ko/LC_MESSAGES/appendix/appendix.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.03\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-18 14:48+0900\n"
 "PO-Revision-Date: 2023-03-20 23:41+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/appendix/resource_and_scheduler.po
+++ b/docs/locale/ko/LC_MESSAGES/appendix/resource_and_scheduler.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.03\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-12-23 13:53+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/chat/chat.po
+++ b/docs/locale/ko/LC_MESSAGES/chat/chat.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2024, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI WebUI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Web-UI User Guide 24.03\n"
+"Project-Id-Version: Backend.AI Web-UI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-18 16:22+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/cluster_session/cluster_session.po
+++ b/docs/locale/ko/LC_MESSAGES/cluster_session/cluster_session.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI WebUI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI WebUI User Guide 20.09\n"
+"Project-Id-Version: Backend.AI WebUI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-18 15:32+0900\n"
 "PO-Revision-Date: 2021-03-16 21:05+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/disclaimer.po
+++ b/docs/locale/ko/LC_MESSAGES/disclaimer.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-01-21 10:40+0900\n"
 "PO-Revision-Date: 2021-01-21 10:41+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/header/header.po
+++ b/docs/locale/ko/LC_MESSAGES/header/header.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI WebUI User Guide\n"
+"Project-Id-Version: Backend.AI WebUI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-14 12:29+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/import_run/import_run.po
+++ b/docs/locale/ko/LC_MESSAGES/import_run/import_run.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-10 18:25+0900\n"
 "PO-Revision-Date: 2022-05-17 11:22+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/index.po
+++ b/docs/locale/ko/LC_MESSAGES/index.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-20 14:43+0900\n"
 "PO-Revision-Date: 2021-03-02 18:12+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/installation/installation.po
+++ b/docs/locale/ko/LC_MESSAGES/installation/installation.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-23 15:24+0900\n"
 "PO-Revision-Date: 2021-03-02 18:16+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/license_agreement/license_agreement.po
+++ b/docs/locale/ko/LC_MESSAGES/license_agreement/license_agreement.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-09 18:45+0900\n"
 "PO-Revision-Date: 2021-03-02 18:15+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/login/login.po
+++ b/docs/locale/ko/LC_MESSAGES/login/login.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.

--- a/docs/locale/ko/LC_MESSAGES/model_serving/model_serving.po
+++ b/docs/locale/ko/LC_MESSAGES/model_serving/model_serving.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2023, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI WebUI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI WebUI User Guide 23.03\n"
+"Project-Id-Version: Backend.AI WebUI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-10 13:35+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/mount_vfolder/mount_vfolder.po
+++ b/docs/locale/ko/LC_MESSAGES/mount_vfolder/mount_vfolder.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <jpark@lablup.com>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 24.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-11 12:30+0900\n"
 "PO-Revision-Date: 2023-03-25 23:38+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/my_environments/my_environments.po
+++ b/docs/locale/ko/LC_MESSAGES/my_environments/my_environments.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2023, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI WebUI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI WebUI User Guide 23.09\n"
+"Project-Id-Version: Backend.AI WebUI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-08-21 04:06+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/overview/overview.po
+++ b/docs/locale/ko/LC_MESSAGES/overview/overview.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-09-12 17:05+0900\n"
 "PO-Revision-Date: 2021-03-02 20:43+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/quickstart.po
+++ b/docs/locale/ko/LC_MESSAGES/quickstart.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2022, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Web-UI
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Web-UI User Guide 23.03\n"
+"Project-Id-Version: Backend.AI Web-UI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-04-06 14:21+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/references/references.po
+++ b/docs/locale/ko/LC_MESSAGES/references/references.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-04-04 17:39+0900\n"
 "PO-Revision-Date: 2021-03-02 18:15+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/session_list/session_list.po
+++ b/docs/locale/ko/LC_MESSAGES/session_list/session_list.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-10-31 02:49+0900\n"
 "PO-Revision-Date: 2020-09-12 11:12+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/session_use/session_use.po
+++ b/docs/locale/ko/LC_MESSAGES/session_use/session_use.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-10-31 02:49+0900\n"
 "PO-Revision-Date: 2020-09-12 11:11+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
+++ b/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.

--- a/docs/locale/ko/LC_MESSAGES/sftp_to_container/sftp_to_container.po
+++ b/docs/locale/ko/LC_MESSAGES/sftp_to_container/sftp_to_container.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-06-13 11:09+0900\n"
 "PO-Revision-Date: 2023-03-20 19:09+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/share_vfolder/share_vfolder.po
+++ b/docs/locale/ko/LC_MESSAGES/share_vfolder/share_vfolder.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # Essential Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console Essential Guide Enterprise R2\n"
+"Project-Id-Version: Backend.AI Console Essential Guide Enterprise 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-14 11:34+0900\n"
 "PO-Revision-Date: 2021-01-21 11:13+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/start/start.po
+++ b/docs/locale/ko/LC_MESSAGES/start/start.po
@@ -2,11 +2,11 @@
 # Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI WebUI
 # User Guide package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI WebUI User Guide\n"
+"Project-Id-Version: Backend.AI WebUI User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-10 14:08+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/docs/locale/ko/LC_MESSAGES/statistics/statistics.po
+++ b/docs/locale/ko/LC_MESSAGES/statistics/statistics.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 20.03\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-28 18:06+0900\n"
 "PO-Revision-Date: 2021-03-02 18:12+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/summary/summary.po
+++ b/docs/locale/ko/LC_MESSAGES/summary/summary.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-08 17:34+0900\n"
 "PO-Revision-Date: 2021-03-02 18:31+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/trouble_shooting/trouble_shooting.po
+++ b/docs/locale/ko/LC_MESSAGES/trouble_shooting/trouble_shooting.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console User Guide 19.09\n"
+"Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-25 23:32+0900\n"
 "PO-Revision-Date: 2023-03-25 23:41+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/user_settings/user_settings.po
+++ b/docs/locale/ko/LC_MESSAGES/user_settings/user_settings.po
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # Essential Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Backend.AI Console Essential Guide Enterprise R2\n"
+"Project-Id-Version: Backend.AI Console Essential Guide Enterprise 25.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-10 23:44+0900\n"
 "PO-Revision-Date: 2023-03-25 11:27+0900\n"

--- a/docs/locale/ko/LC_MESSAGES/vfolder/vfolder.po
+++ b/docs/locale/ko/LC_MESSAGES/vfolder/vfolder.po
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) 2020, Lablup Inc.
+# Copyright (C) 2025, Lablup Inc.
 # This file is distributed under the same license as the Backend.AI Console
 # User Guide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.


### PR DESCRIPTION
resolves FR-746

### update version numbers to 25.05

- We didn't update the documentation for 'th' and 'ja', so I only revised the version marker to 25.05 for the 'ko' translation.