### PR TITLE
docs(FR-1586): update installation page for 25.15.

### DIFF
--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -3,8 +3,8 @@ Installation
 ============
 
 Backend.AI WebUI can be used in two different forms. 
-It can be used as a web service by connecting to a seperate web address provided by the admins, 
-or as an form of app provided as a stand-alone executable file which does not require seperate installation.
+It can be used as a web service by connecting to a separate web address provided by the admins, 
+or as an form of app provided as a stand-alone executable file which does not require separate installation.
 
 With web-based form of WebUI, users just need the latest versions of web browsers, no need to install platform-dependent desktop applications.
 

--- a/docs/locale/ko/LC_MESSAGES/installation/installation.po
+++ b/docs/locale/ko/LC_MESSAGES/installation/installation.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-23 15:24+0900\n"
+"POT-Creation-Date: 2025-10-23 15:40+0900\n"
 "PO-Revision-Date: 2021-03-02 18:16+0900\n"
 "Last-Translator: \n"
 "Language: ko\n"
@@ -24,44 +24,39 @@ msgid "Installation"
 msgstr "설치"
 
 #: ../../installation/installation.rst:5
-#, fuzzy
 msgid ""
 "Backend.AI WebUI can be used in two different forms. It can be used as a "
-"web service by connecting to a seperate web address provided by the "
+"web service by connecting to a separate web address provided by the "
 "admins, or as an form of app provided as a stand-alone executable file "
-"which does not require seperate installation."
+"which does not require separate installation."
 msgstr ""
-"Web-UI는 두 가지 형태로 사용할 수 있습니다. 관리자가 설치한 별도의 웹 주소로 접속하여 웹 서비스 형태로 이용할 수 있고, "
-"별도 설치가 필요 없는 standalone 실행파일로 제공되는 앱 형태로 이용할 수도 있습니다."
+"Backend.AI Web-UI는 두 가지 형태로 사용할 수 있습니다. 관리자가 제공하는 별도의 웹 주소에 접속하여 웹 서비스 형태로 사용하거나, "
+"별도의 설치가 필요 없는 단독 실행 파일 형태의 앱으로 사용할 수 있습니다."
 
 #: ../../installation/installation.rst:9
 msgid ""
 "With web-based form of WebUI, users just need the latest versions of web "
 "browsers, no need to install platform-dependent desktop applications."
-msgstr ""
+msgstr "웹 서비스 형태의 Web-UI는 플랫폼 의존적인 데스크톱 앱을 따로 설치할 필요 없이 최신 웹 브라우저만 있으면 됩니다."
 
 #: ../../installation/installation.rst:11
-#, fuzzy
 msgid "Recommended browser: Latest version of Chrome (at least > 80)"
 msgstr "권장 브라우저: 최신 크롬 (최소한 버전 80 이상)"
 
 #: ../../installation/installation.rst:12
-#, fuzzy
 msgid "Requirement: Any machine that runs web browser (2 cores, 4 GiB memory)"
 msgstr "요구사항: 웹 브라우저를 구동할 수 있는 머신 (2 코어, 4 GiB 메모리)"
 
 #: ../../installation/installation.rst:15
-#, fuzzy
 msgid ""
 "We do not support Microsoft Internet Explorer since it is deprecated and "
 "does not follow web standard, and does not support up-to-date browser "
 "features."
 msgstr ""
-"마이크로소프트의 Internet Explorer 브라우저 개발이 중단되었고 웹 표준 및 최신 브라우저 기능을 충실히 따르지 않으므로"
-" 지원하지 않습니다."
+"마이크로소프트의 인터넷 익스플로러는 더 이상 지원되지 않으며, 웹 표준 및 최신 브라우저 기능을 준수하지 않기 때문에 지원 대상에서"
+" 제외되었습니다."
 
 #: ../../installation/installation.rst:18
-#, fuzzy
 msgid ""
 "The stand-alone WebUI app can be downloaded from following link: "
 "https://github.com/lablup/backend.ai-webui/releases"
@@ -70,23 +65,9 @@ msgstr ""
 ".ai-webui/releases"
 
 #: ../../installation/installation.rst:22
-#, fuzzy
 msgid ""
 "Depending on the security settings of the Operating System, our installer"
 " may be recognized as an unsigned executable file. Permission check may "
 "be required."
-msgstr "앱 형태의 경우 데스크톱 운영체제의 보안 설정에 따라 서명되지 않은 실행파일로 인식되어 권한 허용 절차가 필요할 수 있습니다."
-
-#~ msgid ""
-#~ "With the web-based Web-UI, users"
-#~ " do not need to install a "
-#~ "platform-dependent desktop applications and "
-#~ "just need the latest versions of "
-#~ "browsers such as Chrome."
-#~ msgstr ""
-#~ "Web-UI는 관리자가 제공하는 별도의 웹 주소로 "
-#~ "접속하여 웹 서비스 형태로 이용할 수 있습니다. "
-#~ "사용자는 플랫폼 의존적인 데스크톱 앱을 따로 설치할 "
-#~ "필요가 없으며, Chrome 등과 같은 최신 브라우저만 "
-#~ "있으면 설치하면 됩니다."
+msgstr "운영체제의 보안 설정에 따라 설치 프로그램이 서명되지 않은 실행 파일로 인식될 수 있습니다. 권한 확인이 필요할 수 있습니다."
 


### PR DESCRIPTION
Resolves #128 ([FR-1586](https://lablup.atlassian.net/browse/FR-1586))
[Installation — Backend.AI WebUI User Guide 25.15 documentation.pdf](https://github.com/user-attachments/files/23091658/Installation.Backend.AI.WebUI.User.Guide.25.15.documentation.pdf)
[설치 — Backend.AI WebUI User Guide 25.15 문서.pdf](https://github.com/user-attachments/files/23091659/Backend.AI.WebUI.User.Guide.25.15.pdf)

### TL;DR

Fixed spelling errors in the installation documentation and updated Korean translations.

### What changed?

- Corrected the spelling of "separate" in the English installation documentation
- Updated the Korean translation to match the corrected English text
- Updated the POT creation date in the Korean translation file
- Improved the quality and clarity of several Korean translations

### How to test?

- Review the English documentation to verify the spelling corrections
- Check the Korean translations to ensure they accurately reflect the English content
- Verify that the documentation renders correctly in both languages

### Why make this change?

These corrections improve the quality and professionalism of the documentation. Proper spelling in the English version ensures clarity for users, while the updated Korean translations provide a more accurate and natural reading experience for Korean-speaking users.

[FR-1586]: https://lablup.atlassian.net/browse/FR-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ