### PR TITLE
docs: Add session types and agent selection strategy documentation

### DIFF
--- a/docs/admin_menu/admin_menu.rst
+++ b/docs/admin_menu/admin_menu.rst
@@ -804,6 +804,43 @@ the services. If a direct connection from WSProxy to the Agent node is not
 available, however, please leave this field blank to fall back to the v1 API,
 which relays the traffic through Manager in a traditional way.
 
+Agent Selection Strategy
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When scheduling a session, Backend.AI determines which agent (node) should host
+the session based on the configured strategy. There are two strategies available:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Strategy
+     - Description
+     - Use Cases
+   * - **Dispersed** (default)
+     - Distributes workloads across multiple agents, preferring agents with
+       more available resources for balanced GPU utilization.
+     - Even resource distribution, balanced GPU usage across nodes
+   * - **Concentrated**
+     - Packs workloads onto fewer agents, preferring agents already in use
+       to keep other nodes idle and available for scale-down.
+     - Cloud environments with autoscaling, reducing active node count,
+       cost optimization
+
+**Example**: With 4 GPU nodes and 2 session requests:
+
+- **Dispersed**: Places sessions on Node 1 and Node 2 (distributed across nodes)
+- **Concentrated**: Places both sessions on Node 1 (packed, Node 2-4 remain idle)
+
+.. note::
+   For Inference sessions, the ``enforce_spreading_endpoint_replica`` option can
+   be enabled to spread replicas across different agents even when using the
+   Concentrated strategy. This ensures model serving replicas are not all on
+   the same node.
+
+Scheduler Options
+~~~~~~~~~~~~~~~~~
+
 The resource group has further Scheduler Options. The details are described below.
 
 * Allowed session types:

--- a/docs/locale/ko/LC_MESSAGES/admin_menu/admin_menu.po
+++ b/docs/locale/ko/LC_MESSAGES/admin_menu/admin_menu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-19 17:59+0900\n"
+"POT-Creation-Date: 2026-01-16 17:23+0900\n"
 "PO-Revision-Date: 2022-05-17 22:53+0900\n"
 "Last-Translator: \n"
 "Language: ko\n"
@@ -930,12 +930,13 @@ msgid "Unified View for Pending Sessions"
 msgstr "Pending 상태 세션 통합 뷰"
 
 #: ../../admin_menu/admin_menu.rst:539
+#, fuzzy
 msgid ""
 "From Backend.AI version 25.13.0, a unified view for pending sessions is "
 "available in the Admin Menu. Unlike the Session page, the Scheduler page "
 "provides a unified view of all pending sessions within a selected "
-"resource group. The index number displayed next th the status indicates "
-"the queue position in witch the session will be created once sufficient "
+"resource group. The index number displayed next to the status indicates "
+"the queue position in which the session will be created once sufficient "
 "resources become available."
 msgstr ""
 "Backend.AI 25.13.0 버전부터 Pending 상태의 세션에 대한 스케쥴러 페이지가 관리자 메뉴로 제공됩니다. 세션 "
@@ -1185,9 +1186,8 @@ msgid ""
 "toggling the Enabled switch in the registry list to allow users to access"
 " images from the registry."
 msgstr ""
-"레지스트리를 생성하고 이미지 메타데이터를 업데이트한 후에도 사용자는 바로 이미지를 사용할 "
-"수 없습니다. 레지스트리 목록에서 Enabled 스위치를 켜야 사용자가 해당 레지스트리의 "
-"이미지에 접근할 수 있습니다."
+"레지스트리를 생성하고 이미지 메타데이터를 업데이트한 후에도 사용자는 바로 이미지를 사용할 수 없습니다. 레지스트리 목록에서 "
+"Enabled 스위치를 켜야 사용자가 해당 레지스트리의 이미지에 접근할 수 있습니다."
 
 #: ../../admin_menu/admin_menu.rst:681
 msgid "Manage resource preset"
@@ -1391,7 +1391,98 @@ msgstr ""
 "Agent 가 설치된 노드로 직접적인 네트워크 연결이 불가능한 경우에는, 이 필드를 빈 값으로 설정하여 Manager 를 거쳐 "
 "컨테이너로 트래픽을 중계하는 v1 API 를 사용할 수 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:807
+#: ../../admin_menu/admin_menu.rst:808
+msgid "Agent Selection Strategy"
+msgstr "에이전트 선택 전략"
+
+#: ../../admin_menu/admin_menu.rst:810
+msgid ""
+"When scheduling a session, Backend.AI determines which agent (node) "
+"should host the session based on the configured strategy. There are two "
+"strategies available:"
+msgstr ""
+"세션을 스케줄링할 때, Backend.AI는 설정된 전략에 따라 세션을 호스팅할 에이전트(노드)를 결정합니다. "
+"두 가지 전략을 사용할 수 있습니다:"
+
+#: ../../admin_menu/admin_menu.rst:817
+msgid "Strategy"
+msgstr "전략"
+
+#: ../../admin_menu/admin_menu.rst:818
+msgid "Description"
+msgstr "설명"
+
+#: ../../admin_menu/admin_menu.rst:819
+msgid "Use Cases"
+msgstr "사용 사례"
+
+#: ../../admin_menu/admin_menu.rst:820
+msgid "**Dispersed** (default)"
+msgstr "**Dispersed** (기본값)"
+
+#: ../../admin_menu/admin_menu.rst:821
+msgid ""
+"Distributes workloads across multiple agents, preferring agents with more"
+" available resources for balanced GPU utilization."
+msgstr ""
+"여러 에이전트에 워크로드를 분산하며, 가용 리소스가 많은 에이전트를 우선 선택하여 "
+"GPU 사용률을 균등하게 유지합니다."
+
+#: ../../admin_menu/admin_menu.rst:823
+msgid "Even resource distribution, balanced GPU usage across nodes"
+msgstr "균등한 리소스 분배, 노드 간 균형 잡힌 GPU 사용"
+
+#: ../../admin_menu/admin_menu.rst:824
+msgid "**Concentrated**"
+msgstr "**Concentrated**"
+
+#: ../../admin_menu/admin_menu.rst:825
+msgid ""
+"Packs workloads onto fewer agents, preferring agents already in use to "
+"keep other nodes idle and available for scale-down."
+msgstr ""
+"적은 수의 에이전트에 워크로드를 집중하며, 이미 사용 중인 에이전트를 우선 선택하여 "
+"다른 노드는 유휴 상태로 유지하고 축소(scale-down)가 가능하도록 합니다."
+
+#: ../../admin_menu/admin_menu.rst:827
+msgid ""
+"Cloud environments with autoscaling, reducing active node count, cost "
+"optimization"
+msgstr "오토스케일링이 적용된 클라우드 환경, 활성 노드 수 감소, 비용 최적화"
+
+#: ../../admin_menu/admin_menu.rst:830
+msgid "**Example**: With 4 GPU nodes and 2 session requests:"
+msgstr "**예시**: 4개의 GPU 노드에서 2개의 세션을 요청하는 경우:"
+
+#: ../../admin_menu/admin_menu.rst:832
+msgid ""
+"**Dispersed**: Places sessions on Node 1 and Node 2 (distributed across "
+"nodes)"
+msgstr "**Dispersed**: 노드 1과 노드 2에 각각 세션 배치 (노드 간 분산)"
+
+#: ../../admin_menu/admin_menu.rst:833
+msgid ""
+"**Concentrated**: Places both sessions on Node 1 (packed, Node 2-4 remain"
+" idle)"
+msgstr "**Concentrated**: 노드 1에 두 세션 모두 배치 (집중, 노드 2-4는 유휴 상태 유지)"
+
+#: ../../admin_menu/admin_menu.rst:836
+msgid ""
+"For Inference sessions, the ``enforce_spreading_endpoint_replica`` option"
+" can be enabled to spread replicas across different agents even when "
+"using the Concentrated strategy. This ensures model serving replicas are "
+"not all on the same node."
+msgstr ""
+"Inference 세션의 경우, Concentrated 전략을 사용하더라도 "
+"``enforce_spreading_endpoint_replica`` 옵션을 활성화하면 replica를 "
+"여러 에이전트에 분산할 수 있습니다. 이를 통해 모델 서빙 replica가 "
+"모두 동일한 노드에 배치되는 것을 방지할 수 있습니다."
+
+#: ../../admin_menu/admin_menu.rst:842
+msgid "Scheduler Options"
+msgstr "스케줄러 옵션"
+
+#: ../../admin_menu/admin_menu.rst:844
 msgid ""
 "The resource group has further Scheduler Options. The details are "
 "described below."
@@ -1399,7 +1490,7 @@ msgstr ""
 "리소스 그룹에서 스케줄러 관련 옵션(Scheduler Options)을 추가 설정할 수도 있습니다. 각 항목별 설정은 아래 내용을 "
 "참고하세요."
 
-#: ../../admin_menu/admin_menu.rst:809
+#: ../../admin_menu/admin_menu.rst:846
 msgid ""
 "Allowed session types: Since user can choose the type of session, "
 "resource group can allow certain type of session. You should allow at "
@@ -1410,7 +1501,7 @@ msgstr ""
 "타입의 세션만 허용할 수 있음. 하나 이상의 세션 타입을 허용해야 하며, 허용되는 타입은 Interactive, Batch, "
 "Inference 임."
 
-#: ../../admin_menu/admin_menu.rst:812
+#: ../../admin_menu/admin_menu.rst:849
 msgid ""
 "Pending timeout: A compute session will be canceled if it stays "
 "``PENDING`` status for longer than the Pending timeout. When you wish to "
@@ -1422,7 +1513,7 @@ msgstr ""
 "경우, 해당 세션을 취소함. 무한히 PENDING 상태에 머무르는 세션을 방지하고자 할 때 기준 시간을 설정할 수 있음. 0을 "
 "설정하면 Pending timeout이 적용되지 않음."
 
-#: ../../admin_menu/admin_menu.rst:817
+#: ../../admin_menu/admin_menu.rst:854
 msgid ""
 "Retries to skip pending session: The number of retries the scheduler "
 "tries before skipping a PENDING session. It can be configured to prevent "
@@ -1436,7 +1527,7 @@ msgstr ""
 "(Head-of-line blocking, HOL)를 방지하기 위해 설정할 수 있음. 따로 설정하지 않는 경우에는 Etcd 에 "
 "설정된 글로벌 값 (num_retries_to_skip, 기본 3 회)을 사용함."
 
-#: ../../admin_menu/admin_menu.rst:824
+#: ../../admin_menu/admin_menu.rst:861
 msgid ""
 "You can create a new resource policy by clicking the '+ Create' button. "
 "Likewise other creating options, you cannot create a resource policy with"
@@ -1449,11 +1540,11 @@ msgstr ""
 msgid "Create resource group dialog"
 msgstr "자원 그룹 생성 다이얼로그"
 
-#: ../../admin_menu/admin_menu.rst:835
+#: ../../admin_menu/admin_menu.rst:872
 msgid "Storages"
 msgstr "저장소"
 
-#: ../../admin_menu/admin_menu.rst:837
+#: ../../admin_menu/admin_menu.rst:874
 msgid ""
 "On STORAGES tab, you can see what kind of mount volumes (usually NFS) "
 "exist. From 23.03 version, We provide per-user/per-project quota setting "
@@ -1465,13 +1556,13 @@ msgstr ""
 "쿼타 관리를 지원하는 스토리지에 대해 사용자별/프로젝트별 쿼타 설정이 가능합니다. 이 기능을 사용함으로써, 관리자는 좀 더 손쉽게 "
 "사용자와 프로젝트용 폴더가 스토리지 내에서 얼마만큼 공간을 차지하고 있는지 확인하고 관리할 수 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:843
+#: ../../admin_menu/admin_menu.rst:880
 msgid ""
 "In order to set quota, you need to first access to storages tab in "
 "resource page. And then, click 'Setting (Gear)' in control column."
 msgstr "쿼타를 설정하기 위해서는 자원 페이지의 '저장소(Storage)' 탭을 누르고, 컨트롤 컬럼의 '설정' 버튼을 클릭합니다. "
 
-#: ../../admin_menu/admin_menu.rst:847
+#: ../../admin_menu/admin_menu.rst:884
 msgid ""
 "Please remind that quota setting is only available in storage that "
 "provides quota setting (e.g. XFS, CephFS, NetApp, Purestorage, etc.). "
@@ -1483,65 +1574,65 @@ msgstr ""
 "가능합니다. 저장소의 쿼타 설정 기능 제공 여부에 관계없이 쿼타 설정 페이지를 제공하지만, 내부적으로 쿼타 설정을 지원하지 않는 "
 "저장소에 대해서는 쿼타를 설정할 수 없습니다."
 
-#: ../../admin_menu/admin_menu.rst:857
+#: ../../admin_menu/admin_menu.rst:894
 msgid "Quota Setting Panel"
 msgstr "쿼타 설정 패널"
 
-#: ../../admin_menu/admin_menu.rst:859
+#: ../../admin_menu/admin_menu.rst:896
 msgid "In Quota setting page, there are two panels."
 msgstr "쿼타 설정 페이지에는 두개의 패널이 있습니다. "
 
-#: ../../admin_menu/admin_menu.rst:867
+#: ../../admin_menu/admin_menu.rst:904
 msgid "Overview panel"
 msgstr "스토리지 정보 패널"
 
-#: ../../admin_menu/admin_menu.rst:864
+#: ../../admin_menu/admin_menu.rst:901
 msgid "Usage: Shows the actual amount usage of the selected storage."
 msgstr "사용량: 선택된 저장소에서의 실제 사용량"
 
-#: ../../admin_menu/admin_menu.rst:865
+#: ../../admin_menu/admin_menu.rst:902
 msgid "Endpoint: Represents the mount point of the selected storage."
 msgstr "엔드포인트: 선택된 저장소가 스토리지 노드에 마운트된 경로"
 
-#: ../../admin_menu/admin_menu.rst:866
+#: ../../admin_menu/admin_menu.rst:903
 msgid "Backend Type: The type of storage."
 msgstr "백엔드 타입: 저장소의 타입"
 
-#: ../../admin_menu/admin_menu.rst:867
+#: ../../admin_menu/admin_menu.rst:904
 msgid "Capabilities: The supported feature of the selected storage."
 msgstr "지원 기능: 선택된 저장소에서 지원하는 기능"
 
-#: ../../admin_menu/admin_menu.rst:875
+#: ../../admin_menu/admin_menu.rst:912
 msgid "Quota Settings"
 msgstr "시스템 설정 조회"
 
-#: ../../admin_menu/admin_menu.rst:870
+#: ../../admin_menu/admin_menu.rst:907
 msgid "For User: Configure per-user quota setting here."
 msgstr "사용자 대상: 사용자별로 쿼타를 설정합니다."
 
-#: ../../admin_menu/admin_menu.rst:871
+#: ../../admin_menu/admin_menu.rst:908
 msgid "For Project: Configure per-project quota(project-folder) setting here."
 msgstr "프로젝트 대상: 프로젝트별로 쿼타(프로젝트-폴더) 를 설정합니다."
 
-#: ../../admin_menu/admin_menu.rst:872
+#: ../../admin_menu/admin_menu.rst:909
 msgid "ID: Corresponds to user or project id."
 msgstr "ID: 사용자나 프로젝트 ID에 대응합니다."
 
-#: ../../admin_menu/admin_menu.rst:873
+#: ../../admin_menu/admin_menu.rst:910
 msgid "Hard Limit (GB): Currently set hard limit quota for selected quota."
 msgstr "Hard Limit (GB): 선택된 쿼타에서 현재 설정된 Hard Limit 쿼타를 표시합니다."
 
-#: ../../admin_menu/admin_menu.rst:874
+#: ../../admin_menu/admin_menu.rst:911
 msgid ""
 "Control: Provides editing the hard limit or even deleting the quota "
 "setting."
 msgstr "설정: Hard limit 과 같은 설정값을 수정하거나, 쿼타 설정값을 삭제하는 기능을 제공합니다."
 
-#: ../../admin_menu/admin_menu.rst:878
+#: ../../admin_menu/admin_menu.rst:915
 msgid "Set User Quota"
 msgstr "사용자 쿼타 설정하기"
 
-#: ../../admin_menu/admin_menu.rst:880
+#: ../../admin_menu/admin_menu.rst:917
 msgid ""
 "In Backend.AI, there are two types of vfolders created by user and "
 "admin(project). In this section, we would like to show how to check "
@@ -1556,7 +1647,7 @@ msgstr ""
 "확인해주세요. 그 다음, 쿼타를 수정하고 확인할 대상인 사용자를 선택해주세요. 만일 쿼타가 이미 설정되어 있다면, 사용자 ID와 "
 "동일한 쿼타 ID 값이 테이블에 표시된 것을 확인할 수 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:888
+#: ../../admin_menu/admin_menu.rst:925
 msgid ""
 "Of course, if you want to edit the quota, you can simply click the Edit "
 "button in the control column. After Clicking ``Edit`` button, you may see"
@@ -1572,11 +1663,11 @@ msgstr ""
 msgid "Quota settings panel"
 msgstr "쿼타 설정 패널"
 
-#: ../../admin_menu/admin_menu.rst:897
+#: ../../admin_menu/admin_menu.rst:934
 msgid "Set Project Quota"
 msgstr "프로젝트 쿼타 설정하기"
 
-#: ../../admin_menu/admin_menu.rst:899
+#: ../../admin_menu/admin_menu.rst:936
 msgid ""
 "Setting a quota on project-folder is similar to setting a user quota. The"
 " difference between setting project quota and user quota is to confirm "
@@ -1589,11 +1680,11 @@ msgstr ""
 "차이점은, 프로젝트별로 적용되는 쿼타에서는 프로젝트가 소속되어 있는 도메인을 우선 선택하는 과정이 추가되었다는 것입니다. 그 이후 "
 "과정은 동일합니다. 하단 그림에서 볼 수 있듯이, 우선 도메인을 선택하고, 적용할 프로젝트를 선택하면 됩니다."
 
-#: ../../admin_menu/admin_menu.rst:907
+#: ../../admin_menu/admin_menu.rst:944
 msgid "Unset Quota"
 msgstr "쿼타 해제하기"
 
-#: ../../admin_menu/admin_menu.rst:909
+#: ../../admin_menu/admin_menu.rst:946
 msgid ""
 "We also provides the feature to unset the quota. Please remind that after"
 " removing the quota setting, quota will automatically follows user or "
@@ -1613,7 +1704,7 @@ msgstr ""
 "클릭하게 되면, 쿼타 설정값이 삭제되고, 자동으로 쿼타 설정값은 쿼타의 타입(사용자 / 프로젝트)에 대응하는 값으로 적용되게 "
 "됩니다."
 
-#: ../../admin_menu/admin_menu.rst:920
+#: ../../admin_menu/admin_menu.rst:957
 msgid ""
 "If there's no config per user/project, then corresponding values in the "
 "user/project resource policy will be set as a default value. For example,"
@@ -1624,11 +1715,11 @@ msgstr ""
 "예를 들어 쿼타에서 hard limit 값이 설정되어 있지 않다면, 자원 정책 내 ``max_vfolder_size`` 값이 기본 "
 "값으로 쓰이게 됩니다."
 
-#: ../../admin_menu/admin_menu.rst:928
+#: ../../admin_menu/admin_menu.rst:965
 msgid "Download session lists"
 msgstr "세션 자원 다운로드"
 
-#: ../../admin_menu/admin_menu.rst:930
+#: ../../admin_menu/admin_menu.rst:967
 msgid ""
 "This feature is currently not available on the default Session page. To "
 "use this feature, please enable 'Classic Session list page' option in the"
@@ -1641,7 +1732,7 @@ msgstr ""
 ":ref:`Backend.AI 사용자 설정 페이지` Backend.AI 클러스터 세션에 대해 더 자세한 정보를 확인하시려면, "
 ":ref:`Backend.AI 사용자 설정 페이지<user-settings>` 섹션을 참고하십시오. "
 
-#: ../../admin_menu/admin_menu.rst:934
+#: ../../admin_menu/admin_menu.rst:971
 msgid ""
 "There's additional feature in Session page for admin. On the right side "
 "of the FINISHED tab there is a menu marked with ``...``. When you click "
@@ -1650,7 +1741,7 @@ msgstr ""
 "세션 페이지에는 관리자를 위한 추가 기능이 있습니다. FINISHED 탭 우측을 보면 ``…`` 으로 표시된 메뉴가 있습니다. 이 "
 "메뉴를 클릭하면 export CSV 라는 하위 메뉴가 나옵니다."
 
-#: ../../admin_menu/admin_menu.rst:940
+#: ../../admin_menu/admin_menu.rst:977
 msgid ""
 "If you click this menu, you can download the information of the comcpute "
 "sessions created so far in CSV format. After the following dialog opens, "
@@ -1662,11 +1753,11 @@ msgstr ""
 "후, (필요한 경우) 적당한 파일 이름을 입력하고 EXPORT 버튼을 클릭하십시오. 파일 이름은 최대 255 자까지만 입력 가능한 "
 "점에 유의하십시오. 곧 CSV 파일 하나가 다운로드 될 것입니다."
 
-#: ../../admin_menu/admin_menu.rst:951
+#: ../../admin_menu/admin_menu.rst:988
 msgid "System settings"
 msgstr "시스템 설정 조회"
 
-#: ../../admin_menu/admin_menu.rst:953
+#: ../../admin_menu/admin_menu.rst:990
 msgid ""
 "In the Configuration page, you can see main settings of Backend.AI "
 "server. Currently, it provides several controls which can change and list"
@@ -1675,7 +1766,7 @@ msgstr ""
 "Configuration 페이지에서 Backend.AI에 설정된 주요 설정값을 조회할 수 있습니다. 현재는 몇가지 변경 기능 및 "
 "설정 조회 기능을 제공하고 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:957
+#: ../../admin_menu/admin_menu.rst:994
 msgid ""
 "You can change image auto install and update rule by selecting one option"
 " from ``Digest``, ``Tag``, ``None``. ``Digest`` is kind of checksum for "
@@ -1689,7 +1780,7 @@ msgstr ""
 "다운로드의 효율성을 높이는데에 사용됩니다. ``Tag`` 는 개발용 옵션에만 사용할 수 있는데, 태그는 이미지의 무결성을 보장하지 "
 "않기 때문입니다."
 
-#: ../../admin_menu/admin_menu.rst:965
+#: ../../admin_menu/admin_menu.rst:1002
 msgid ""
 "Don't change rule selection unless you completely understand the meaning "
 "of each rule."
@@ -1699,7 +1790,7 @@ msgstr "각 규칙에 대해 완전히 이해하고 있지 않는 한 선택된 
 msgid "System setting about image"
 msgstr "이미지 내 자원 제한 값 수정"
 
-#: ../../admin_menu/admin_menu.rst:970
+#: ../../admin_menu/admin_menu.rst:1007
 msgid "You can also change settings for scaling, plugins and enterprise features."
 msgstr "스케일링과 플러그인, 엔터프라이즈 기능에 대한 설정도 변경할 수 있습니다."
 
@@ -1707,7 +1798,7 @@ msgstr "스케일링과 플러그인, 엔터프라이즈 기능에 대한 설정
 msgid "System setting about scaling and plugins"
 msgstr ""
 
-#: ../../admin_menu/admin_menu.rst:975
+#: ../../admin_menu/admin_menu.rst:1012
 msgid ""
 "When a user launches a multi-node cluster session, which is introduced at"
 " version 20.09, Backend.AI will dynamically create an overlay network to "
@@ -1724,7 +1815,7 @@ msgstr ""
 msgid "Overlay network setting dialog"
 msgstr ""
 
-#: ../../admin_menu/admin_menu.rst:987
+#: ../../admin_menu/admin_menu.rst:1024
 msgid ""
 "For more information about Backend.AI Cluster session, please refer to "
 ":ref:`Backend.AI Cluster Compute Session<backendai-cluster-compute-"
@@ -1733,7 +1824,7 @@ msgstr ""
 "Backend.AI 클러스터 세션에 대해 더 자세한 정보를 확인하시려면, :ref:`Backend.AI 클러스터 연산 세션"
 "<backendai-cluster-compute-session>` 섹션을 참고하십시오."
 
-#: ../../admin_menu/admin_menu.rst:990
+#: ../../admin_menu/admin_menu.rst:1027
 msgid ""
 "You can edit the configuration per job scheduler by clicking the "
 "Scheduler's config button. The values in the scheduler setting are the "
@@ -1745,7 +1836,7 @@ msgstr ""
 "그룹<scheduling-methods>` 의 스케줄러 설정값이 없을 때 사용하는 기본 값을 의미합니다. 자원 그룹에 설정한 값이 "
 "있을 경우, 이 값은 무시됩니다."
 
-#: ../../admin_menu/admin_menu.rst:995
+#: ../../admin_menu/admin_menu.rst:1032
 msgid ""
 "Currently supported scheduling methods include ``FIFO``, ``LIFO``, and "
 "``DRF``. Each method of scheduling is exactly the same as the "
@@ -1765,27 +1856,27 @@ msgstr ""
 msgid "System setting dialog scheduler settings"
 msgstr ""
 
-#: ../../admin_menu/admin_menu.rst:1008
+#: ../../admin_menu/admin_menu.rst:1045
 msgid "We will continue to add broader range of setting controls."
 msgstr "향후 CLI에서 지원하는 다양한 설정 변경 기능을 GUI에도 계속 추가할 예정입니다."
 
-#: ../../admin_menu/admin_menu.rst:1011
+#: ../../admin_menu/admin_menu.rst:1048
 msgid ""
 "System settings are default settings. If resource group has certain "
 "value, then it overrides configured value in system settings."
 msgstr "시스템 설정값은 기본 설정입니다. 자원 그룹에서 특정 값이 설정된 경우, 시스템 설정값이 아닌 자원 그룹 설정값을 적용합니다."
 
-#: ../../admin_menu/admin_menu.rst:1016
+#: ../../admin_menu/admin_menu.rst:1053
 msgid "Server management"
 msgstr "서버 관리 메뉴"
 
-#: ../../admin_menu/admin_menu.rst:1018
+#: ../../admin_menu/admin_menu.rst:1055
 msgid ""
 "Go to the Maintenance page and you will see some buttons to manage the "
 "server."
 msgstr "Maintenance 페이지로 이동하면 서버를 관리할 수 있는 몇 가지 버튼을 볼 수 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:1020
+#: ../../admin_menu/admin_menu.rst:1057
 msgid ""
 "RECALCULATE USAGE: Occasionally, due to unstable network connections or "
 "container management problem of Docker daemon, there may be a case where "
@@ -1797,7 +1888,7 @@ msgstr ""
 "Backend.AI에서 출력되는 자원 점유량이 일치하지 않는 경우가 있을 수 있습니다. 그 때 RECALCULATE USAGE "
 "버튼을 클릭하면 자원 점유량을 수동 보정할 수 있습니다."
 
-#: ../../admin_menu/admin_menu.rst:1025
+#: ../../admin_menu/admin_menu.rst:1062
 msgid ""
 "RESCAN IMAGES: Update image meta information from all registered Docker "
 "registries. It can be used when a new image is pushed to a Backend.AI-"
@@ -1810,17 +1901,17 @@ msgstr ""
 msgid "Maintenance page"
 msgstr ""
 
-#: ../../admin_menu/admin_menu.rst:1035
+#: ../../admin_menu/admin_menu.rst:1072
 msgid ""
 "We will continue to add other settings needed for management, such as "
 "removing unused images or registering periodic maintenance schedules."
 msgstr "사용하지 않는 이미지를 제거하거나, 주기적 관리 일정 등록 등 기타 관리에 필요한 설정이 계속 추가될 예정입니다."
 
-#: ../../admin_menu/admin_menu.rst:1040
+#: ../../admin_menu/admin_menu.rst:1077
 msgid "Detailed Information"
 msgstr "상세 정보"
 
-#: ../../admin_menu/admin_menu.rst:1042
+#: ../../admin_menu/admin_menu.rst:1079
 msgid ""
 "In Information page, you can see several detailed information and status "
 "of each feature. To see Manager version and API version, check the Core "
@@ -1831,7 +1922,7 @@ msgstr ""
 "Core 패널을 확인하십시오. Backend.AI를 구성하는 각 컴포넌트의 호환 가능 여부를 보려면 Component 패널을 "
 "확인하십시오."
 
-#: ../../admin_menu/admin_menu.rst:1048
+#: ../../admin_menu/admin_menu.rst:1085
 msgid "This page is only for showing current information."
 msgstr "이 페이지는 현재 정보를 보여주기 위한 것입니다."
 

--- a/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
+++ b/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
@@ -67,11 +67,14 @@ msgstr ""
 #: ../../sessions_all/sessions_all.rst:33
 msgid ""
 "Session type: Determines the type of the session. Backend.AI supports "
-"four session types: Interactive, Batch, Inference, and System. The "
-"following are the primary distinctions between each type:"
+"four session types: Interactive, Batch, Inference, and System. Users can "
+"select from Interactive, Batch, and Inference types, while System "
+"sessions are managed automatically by the platform. The following are the "
+"primary distinctions between each type:"
 msgstr ""
 "세션 타입: 세션의 형태를 결정합니다. Backend.AI는 Interactive, Batch, Inference, System의 "
-"네 가지 세션 형태를 지원합니다. 각 형태의 주요한 차이점은 다음과 같습니다:"
+"네 가지 세션 형태를 지원합니다. 사용자는 Interactive, Batch, Inference 타입 중에서 선택할 수 "
+"있으며, System 세션은 플랫폼에서 자동으로 관리됩니다. 각 형태의 주요한 차이점은 다음과 같습니다:"
 
 #: ../../sessions_all/sessions_all.rst:37
 msgid "Interactive compute session"

--- a/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
+++ b/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
@@ -56,13 +56,11 @@ msgid "Session Type"
 msgstr "세션 타입"
 
 #: ../../sessions_all/sessions_all.rst:28
-#, fuzzy
 msgid ""
 "In the first page, users can select the type of session. If needed, "
 "setting the name of the session (optional) is also available."
 msgstr ""
-"첫 번째 페이지에서는 세션의 형태인 interactive 또는 batch를 선택해야 합니다. 그리고 세션 이름을 지정할 수 "
-"있습니다. (선택사항)"
+"첫 번째 페이지에서는 세션 타입을 선택할 수 있습니다. 필요한 경우 세션 이름을 지정할 수도 있습니다. (선택사항)"
 
 #: ../../sessions_all/sessions_all.rst:33
 msgid ""

--- a/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
+++ b/docs/locale/ko/LC_MESSAGES/sessions_all/sessions_all.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Backend.AI Console User Guide 25.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-24 17:58+0900\n"
+"POT-Creation-Date: 2026-01-16 17:23+0900\n"
 "PO-Revision-Date: 2024-03-05 16:00+0900\n"
 "Last-Translator: \n"
 "Language: ko_KR\n"
@@ -56,41 +56,41 @@ msgid "Session Type"
 msgstr "세션 타입"
 
 #: ../../sessions_all/sessions_all.rst:28
+#, fuzzy
 msgid ""
-"In the first page, users can select the type of session, 'interactive' or"
-" 'batch'. If needed, setting the name of the session (optional) is also "
-"available."
+"In the first page, users can select the type of session. If needed, "
+"setting the name of the session (optional) is also available."
 msgstr ""
 "첫 번째 페이지에서는 세션의 형태인 interactive 또는 batch를 선택해야 합니다. 그리고 세션 이름을 지정할 수 "
 "있습니다. (선택사항)"
 
 #: ../../sessions_all/sessions_all.rst:33
 msgid ""
-"Session type: Determines the type of the session. There are two different"
-" types of session, \\\"Interactive\\\" and \\\"Batch\\\". The following "
-"are the primary distinctions between the two types:"
+"Session type: Determines the type of the session. Backend.AI supports "
+"four session types: Interactive, Batch, Inference, and System. The "
+"following are the primary distinctions between each type:"
 msgstr ""
-"세션 타입: 세션의 형태를 결정합니다. 현재 가능한 세션 형태는 “Interactive” 와 “Batch” 두 가지가 있습니다. 두"
-" 형태의 주요한 차이점은 다음과 같습니다:"
+"세션 타입: 세션의 형태를 결정합니다. Backend.AI는 Interactive, Batch, Inference, System의 "
+"네 가지 세션 형태를 지원합니다. 각 형태의 주요한 차이점은 다음과 같습니다:"
 
-#: ../../sessions_all/sessions_all.rst:36
+#: ../../sessions_all/sessions_all.rst:37
 msgid "Interactive compute session"
 msgstr "Interactive 형태 연산 세션"
 
-#: ../../sessions_all/sessions_all.rst:38
+#: ../../sessions_all/sessions_all.rst:39
 msgid ""
 "This is the type which has been supported from the initial version of the"
 " Backend.AI."
 msgstr "Backend.AI 초기 버전부터 지원하던 형태입니다."
 
-#: ../../sessions_all/sessions_all.rst:39
+#: ../../sessions_all/sessions_all.rst:40
 msgid ""
 "The compute session is used in a way that the user interacts with after "
 "creating a session without specifying a pre-defined execution script or "
 "command."
 msgstr "사용자가 별도의 실행 스크립트를 지정하지 않고 일단 세션을 생성한 후 상호 작용하는 방식으로 세션을 사용하게 됩니다."
 
-#: ../../sessions_all/sessions_all.rst:42
+#: ../../sessions_all/sessions_all.rst:43
 msgid ""
 "The session is not terminated automatically unless user explicitly "
 "destroys the session or session garbage collectors are set by the admin."
@@ -98,23 +98,23 @@ msgstr ""
 "사용자가 명시적으로 삭제하지 않는 한 세션은 자동 삭제되지 않습니다. 다만, 관리자가 별도의 세션 자동 수거 설정을 켜둔 경우에는,"
 " 그 조건에 따라 자동으로 삭제될 수도 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:45
+#: ../../sessions_all/sessions_all.rst:46
 msgid "Batch compute session"
 msgstr "Batch 형태 연산 세션"
 
-#: ../../sessions_all/sessions_all.rst:47
+#: ../../sessions_all/sessions_all.rst:48
 msgid ""
 "This type of session is supported via GUI from Backend.AI 22.03 (CLI has "
 "supported the batch-type session before the 22.03)."
 msgstr "Backend.AI 22.03 부터 GUI 를 통해 제공합니다. 다만, CLI 의 경우에는 그 이전부터 지원하고 있었습니다."
 
-#: ../../sessions_all/sessions_all.rst:49
+#: ../../sessions_all/sessions_all.rst:50
 msgid ""
 "Pre-define the script that will be executed when a compute session is "
 "ready."
 msgstr "사용자가 연산 세션을 생성할 때 실행할 스크립트를 미리 지정합니다."
 
-#: ../../sessions_all/sessions_all.rst:51
+#: ../../sessions_all/sessions_all.rst:52
 msgid ""
 "This session will execute the script as soon as the compute session is "
 "ready, and then automatically terminates the session as soon as the "
@@ -126,7 +126,7 @@ msgstr ""
 "코드가 사전에 정의되어 있거나 작업을 파이프라이닝 하는 경우에는, 연산 서버 팜(server farm)의 자원을 보다 효율적으로 "
 "활용할 수 있는 장점이 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:55
+#: ../../sessions_all/sessions_all.rst:56
 msgid ""
 "Users can set the start time of a batch-type compute session. However, "
 "keep in mind that this feature does not guarantee that the session will "
@@ -138,14 +138,65 @@ msgstr ""
 "부족 등의 이유로 PENDING 상태에 계속 머물 수 있습니다). 시작 시점 이전에는 자원이 있어도 연산 세션을 스케줄링 하지 않는"
 " 개념으로 이해하는 것이 정확합니다."
 
-#: ../../sessions_all/sessions_all.rst:59
+#: ../../sessions_all/sessions_all.rst:60
 msgid ""
 "Users can also set the 'Timeout Duration' of a batch-type compute "
 "session. When users set the timeout duration, The session will "
 "automatically terminate if the specified time is exceeded."
 msgstr "배치 작업 최대 실행 시간: 배치 작업의 최대 실행 시간을 설정합니다. 지정된 시간이 초과되면 세션이 자동으로 종료됩니다."
 
-#: ../../sessions_all/sessions_all.rst:66
+#: ../../sessions_all/sessions_all.rst:67
+msgid "Inference session"
+msgstr "Inference 형태 연산 세션"
+
+#: ../../sessions_all/sessions_all.rst:69
+msgid ""
+"Inference sessions are designed for model serving and production AI "
+"deployments."
+msgstr "Inference 세션은 모델 서빙 및 프로덕션 AI 배포를 위해 설계되었습니다."
+
+#: ../../sessions_all/sessions_all.rst:70
+msgid ""
+"Unlike interactive sessions, inference sessions provide automatic "
+"recovery if terminated unexpectedly, enabling disaster recovery for "
+"production services."
+msgstr ""
+"Interactive 세션과 달리, Inference 세션은 예기치 않게 종료되더라도 자동으로 복구되어 "
+"프로덕션 서비스의 재해 복구를 지원합니다."
+
+#: ../../sessions_all/sessions_all.rst:72
+msgid ""
+"Features persistent endpoint URLs, auto-scaling, and health checks for "
+"reliable model serving infrastructure."
+msgstr ""
+"영구적인 엔드포인트 URL, 오토 스케일링, 헬스 체크 기능을 제공하여 "
+"안정적인 모델 서빙 인프라를 구축할 수 있습니다."
+
+#: ../../sessions_all/sessions_all.rst:74
+msgid ""
+"Requires a model definition file for configuration. See :ref:`Model "
+"Serving <model-serving>` section for details."
+msgstr ""
+"설정을 위해 모델 정의 파일이 필요합니다. 자세한 내용은 "
+":ref:`Model Serving <model-serving>` 섹션을 참조하세요."
+
+#: ../../sessions_all/sessions_all.rst:77
+msgid "System session"
+msgstr "System 형태 연산 세션"
+
+#: ../../sessions_all/sessions_all.rst:79
+msgid ""
+"System sessions are used internally for infrastructure operations such as"
+" sFTP file uploads."
+msgstr "System 세션은 sFTP 파일 업로드와 같은 내부 인프라 작업에 사용됩니다."
+
+#: ../../sessions_all/sessions_all.rst:81
+msgid ""
+"These sessions are not created directly by users; they are managed "
+"automatically by the system."
+msgstr "이 세션은 사용자가 직접 생성하지 않으며, 시스템에 의해 자동으로 관리됩니다."
+
+#: ../../sessions_all/sessions_all.rst:84
 msgid ""
 "Session name: Users can specify the name of the compute session to be "
 "created. If set, this name appears in Session Info, so it is "
@@ -157,7 +208,7 @@ msgstr ""
 "구분이 용이합니다. 지정하지 않으면 임의의 이름이 자동으로 지정됩니다. 세션 이름은 4-64자 사이의 알파벳 또는 숫자만 "
 "받아들이며, 공백은 허용되지 않습니다."
 
-#: ../../sessions_all/sessions_all.rst:72
+#: ../../sessions_all/sessions_all.rst:90
 msgid ""
 "If users create a session with the ``super admin`` or ``admin`` account, "
 "they can additionally assign a session owner. If you enable the toggle, a"
@@ -166,7 +217,7 @@ msgstr ""
 "``super admin`` 혹은 ``admin`` 계정으로 세션을 생성하는 경우, 추가적으로 세션 소유자를 할당할 수 있습니다. "
 "토글을 클릭해 할당을 활성화하면 사용자 이메일 입력 필드가 나타납니다."
 
-#: ../../sessions_all/sessions_all.rst:79
+#: ../../sessions_all/sessions_all.rst:97
 msgid ""
 "Enter the email of the user you want to assign the session to, click the "
 "'search' button, and the user's access key will be automatically "
@@ -175,11 +226,11 @@ msgstr ""
 "세션 할당을 위한 사용자 이메일을 입력하고 '검색' 버튼을 클릭하면, 해당 사용자의 access key가 자동으로 등록됩니다. "
 "추가적으로 프로젝트와 자원 그룹을 선택해 할당할 수 있습니다. "
 
-#: ../../sessions_all/sessions_all.rst:88
+#: ../../sessions_all/sessions_all.rst:106
 msgid "Environments & Resource allocation"
 msgstr "실행 환경 및 자원 할당"
 
-#: ../../sessions_all/sessions_all.rst:92
+#: ../../sessions_all/sessions_all.rst:110
 msgid ""
 "Click the 'Next' button below, or the 'Environments & Resource "
 "allocation' menu on the right to proceed to the next page. If you want to"
@@ -190,17 +241,17 @@ msgstr ""
 "다음 페이지로 진행하려면 아래쪽의 '다음' 버튼을 클릭하거나, 우측의 '실행 환경 & 자원 할당' 버튼을 클릭하십시오. 추가 설정 "
 "없이 세션을 생성하려면 '검토로 건너뛰기' 버튼을 누르십시오. 이 경우, 다른 페이지의 설정은 모두 기본값을 사용하게 됩니다."
 
-#: ../../sessions_all/sessions_all.rst:101
+#: ../../sessions_all/sessions_all.rst:119
 msgid "Environments"
 msgstr "실행 환경"
 
-#: ../../sessions_all/sessions_all.rst:105
+#: ../../sessions_all/sessions_all.rst:123
 msgid ""
 "For detailed explanations of each item that can be set on the second "
 "page, please refer to the following:"
 msgstr "두 번째 페이지에서 설정할 수 있는 각 항목에 대한 자세한 설명은 다음을 참고하십시오."
 
-#: ../../sessions_all/sessions_all.rst:108
+#: ../../sessions_all/sessions_all.rst:126
 msgid ""
 "Environments: Users can select the base environment for compute sessions "
 "such as TensorFlow, PyTorch, C++, etc. The compute session will "
@@ -212,7 +263,7 @@ msgstr ""
 "선택하면 연산 세션에서 TensorFlow 라이브러리를 사용할 수 있습니다. 다른 환경을 선택하면 해당 환경이 기본적으로 설치된 "
 "연산 세션을 생성하게 됩니다."
 
-#: ../../sessions_all/sessions_all.rst:111
+#: ../../sessions_all/sessions_all.rst:129
 msgid ""
 "Version: Users can specify the version of the environment. There are "
 "multiple versions in a single environment. For example, TensorFlow has "
@@ -221,7 +272,7 @@ msgstr ""
 "버전: 사용자는 실행 환경의 버전을 지정할 수 있습니다. 하나의 환경에는 여러 버전이 존재할 수 있습니다. 예를 들어, "
 "TensorFlow는 1.15, 2.3 등 다양한 버전을 제공합니다. "
 
-#: ../../sessions_all/sessions_all.rst:113
+#: ../../sessions_all/sessions_all.rst:131
 msgid ""
 "Image Name: Users can specify the name of the image to be used for the "
 "compute session. This configuration may not be available depending on the"
@@ -230,7 +281,7 @@ msgstr ""
 "환경 이름 (선택사항): 연산 세션에 사용할 이미지의 이름을 지정할 수 있습니다. 환경 설정에 따라 이 설정이 사용 불가능할 수도 "
 "있습니다."
 
-#: ../../sessions_all/sessions_all.rst:115
+#: ../../sessions_all/sessions_all.rst:133
 msgid ""
 "Set Environment Variable: To give more convenient workspace for users, "
 "Backend.AI supports environment variable setting in session launching. In"
@@ -241,11 +292,11 @@ msgstr ""
 "지원합니다. 이 기능에서 여러분은 ``PATH`` 를 비롯한 모든 환경 변수를 설정 다이얼로그에서 변수명과 변숫값을 입력해서 추가할"
 " 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:124
+#: ../../sessions_all/sessions_all.rst:142
 msgid "Resource allocation"
 msgstr "자원 할당"
 
-#: ../../sessions_all/sessions_all.rst:128
+#: ../../sessions_all/sessions_all.rst:146
 msgid ""
 "Resource Group: Specifies the resource group in which to create a compute"
 " session. A resource group is a unit that groups host servers that each "
@@ -263,7 +314,7 @@ msgstr ""
 " 세션을 생성할 수 있습니다. 자원 그룹이 여러 개인 경우 원하는 그룹을 선택할 수 있지만, 하나만 있는 경우에는 변경할 수 "
 "없습니다."
 
-#: ../../sessions_all/sessions_all.rst:136
+#: ../../sessions_all/sessions_all.rst:154
 msgid ""
 "Resource Presets: These templates have pre-defined resource sets, such as"
 " CPU, memory, and GPU, to be allocated to a compute session. "
@@ -274,13 +325,13 @@ msgstr ""
 "자원 프리셋: 이 템플릿은 연산 세션에 할당할 CPU, 메모리, GPU 등의 자원 세트를 미리 정의해 둔 것입니다. 관리자는 미리 "
 "자주 사용하는 자원 설정을 정의할 수 있습니다. 숫자 입력을 조정하거나 슬라이더를 움직이면 원하는 자원량을 할당할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:144
+#: ../../sessions_all/sessions_all.rst:162
 msgid ""
 "The meaning of each item is as follows. Clicking the 'Help (?)' button "
 "will also give more information."
 msgstr "각 항목의 의미는 다음과 같습니다. '도움 (?)' 버튼을 클릭하면 자세한 정보를 확인할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:147
+#: ../../sessions_all/sessions_all.rst:165
 msgid ""
 "CPU: The CPU performs basic arithmetic, logic, controlling, and "
 "input/output (I/O) operations specified by the instructions. In general, "
@@ -292,7 +343,7 @@ msgstr ""
 "많은 CPU가 도움이 되지만, 여러 CPU를 사용하도록 프로그램 코드를 작성해야 합니다. (그렇지 않으면 대부분의 CPU는 사용되지"
 " 않을 것입니다.)"
 
-#: ../../sessions_all/sessions_all.rst:150
+#: ../../sessions_all/sessions_all.rst:168
 msgid ""
 "Memory: Computer memory is a temporary storage area. It holds the data "
 "and instructions that the Central Processing Unit (CPU) needs. When using"
@@ -304,7 +355,7 @@ msgstr ""
 "워크로드를 처리할 때 GPU를 연산 장치로 사용하는 경우, GPU 메모리의 두 배 이상의 메모리를 할당해야 합니다. 그렇지 않으면 "
 "GPU의 유휴 시간이 증가하여 성능이 저하됩니다."
 
-#: ../../sessions_all/sessions_all.rst:155
+#: ../../sessions_all/sessions_all.rst:173
 msgid ""
 "Shared Memory: The amount of shared memory in GB to allocate for the "
 "compute session. Shared memory will use some part of the memory set in "
@@ -313,7 +364,7 @@ msgstr ""
 "공유 메모리: 연산 세션에 할당할 공유 메모리의 용량 (GB). RAM에 설정된 메모리 중 일부를 떼어 공유 메모리로 사용합니다. "
 "따라서, RAM에 지정된 양보다 클 수 없습니다."
 
-#: ../../sessions_all/sessions_all.rst:158
+#: ../../sessions_all/sessions_all.rst:176
 msgid ""
 "AI Accelerator: AI accelerators (GPUs or NPUs) are well-suited for the "
 "matrix/vector computations involved in machine learning. AI accelerators "
@@ -323,7 +374,7 @@ msgstr ""
 "AI 가속기: AI 가속기 (GPU 및 NPU)는 기계 학습과 관련된 행렬 / 벡터 계산에 적합합니다. AI 가속기는 훈련 및 "
 "인퍼런스 알고리즘을 몇 배나 가속화하여 기계 학습 워크로드의 실행 시간을 몇 주에서 며칠로 줄입니다."
 
-#: ../../sessions_all/sessions_all.rst:162
+#: ../../sessions_all/sessions_all.rst:180
 msgid ""
 "Sessions: Session is a unit of computational environment that is created "
 "according to a specified environment and resources. If this value is set "
@@ -336,7 +387,7 @@ msgstr ""
 " 세션이 지정한 값만큼 동시에 생성됩니다. 세션 시작 요청 시 사용 가능한 자원이 충분하지 않은 경우, 생성하지 못한 세션 시작 "
 "요청들은 생성 대기열에 추가됩니다."
 
-#: ../../sessions_all/sessions_all.rst:172
+#: ../../sessions_all/sessions_all.rst:190
 msgid ""
 "Select Agent: Select the agent to be assigned. By default, the agent is "
 "automatically selected by the scheduler. The agent selector displays the "
@@ -347,7 +398,7 @@ msgstr ""
 "에이전트 선택기에서는 각 에이전트의 실제 사용 가능한 자원 양을 확인할 수 있습니다. 현재 이 기능은 단일 노드, 단일 컨테이너 "
 "환경에서만 지원됩니다."
 
-#: ../../sessions_all/sessions_all.rst:175
+#: ../../sessions_all/sessions_all.rst:193
 msgid ""
 "Cluster mode: Cluster mode allows users to create multiple compute "
 "sessions at once. For more information, refer to the :ref:`Overview of "
@@ -357,19 +408,19 @@ msgstr ""
 "정보는 :ref:`Backend.AI 클러스터 연산 세션 개요<backendai-cluster-compute-session>` "
 "섹션을 참고하세요."
 
-#: ../../sessions_all/sessions_all.rst:180
+#: ../../sessions_all/sessions_all.rst:198
 msgid ""
 "The Agent Select feature may not be available depending on the server "
 "environment."
 msgstr "에이전트 선택 기능은 서버 환경에 따라 표시되지 않을 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:182
+#: ../../sessions_all/sessions_all.rst:200
 msgid ""
 "High-Performance Computing Optimizations: Backend.AI provides configuring"
 " values related to HPC Optimizations."
 msgstr "고성능 컴퓨팅 최적화: Backend.AI 는 HPC 최적화 관련 값을 설정할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:185
+#: ../../sessions_all/sessions_all.rst:203
 msgid ""
 "Backend.AI provides configuration UI for internal control variable in "
 "``nthreads-var``. Backend.AI sets this value equal to the number of "
@@ -389,17 +440,17 @@ msgstr ""
 msgid "Session HPC Optimization"
 msgstr "세션 HPC 최적화"
 
-#: ../../sessions_all/sessions_all.rst:198
+#: ../../sessions_all/sessions_all.rst:216
 msgid "Data & Storage"
 msgstr "데이터 및 폴더"
 
-#: ../../sessions_all/sessions_all.rst:202
+#: ../../sessions_all/sessions_all.rst:220
 msgid ""
 "Click the 'Next' button below, or the 'Data & Storage' menu on the right "
 "to proceed to the next page."
 msgstr "다음 페이지로 진행하려면 아래쪽의 '다음' 버튼을 클릭하거나, 우측의 '데이터 & 폴더' 버튼을 클릭하세요."
 
-#: ../../sessions_all/sessions_all.rst:204
+#: ../../sessions_all/sessions_all.rst:222
 msgid ""
 "When a compute session is destroyed, data deletion is set to default. "
 "However, data stored in the mounted folders will survive. Data in those "
@@ -411,10 +462,9 @@ msgstr ""
 "여기서는 연산 세션에 마운트 할 데이터 폴더를 지정할 수 있습니다. 연산 세션이 삭제되면 기본적으로 모든 데이터가 함께 삭제되지만,"
 " 여기서 마운트 한 폴더에 저장된 데이터는 삭제되지 않습니다. 마운트 폴더에 저장된 데이터는 다른 연산 세션을 생성할 때 다시 "
 "마운트하여 재사용할 수도 있습니다. 폴더를 마운트하고 연산 세션을 실행하는 방법에 대한 정보는 :ref:`연산 세션에 폴더 마운트"
-"<session-mounts>` 장을 참고하십시오. 여기서는 폴더를 마운트하지 않고 그냥 지나가겠습니다. 다음 페이지로 "
-"이동합시다."
+"<session-mounts>` 장을 참고하십시오. 여기서는 폴더를 마운트하지 않고 그냥 지나가겠습니다. 다음 페이지로 이동합시다."
 
-#: ../../sessions_all/sessions_all.rst:214
+#: ../../sessions_all/sessions_all.rst:232
 msgid ""
 "users can specify the data folders to mount in the compute session. "
 "Folder explorer can be used by clicking folder name. For further "
@@ -423,7 +473,7 @@ msgstr ""
 "사용자는 연산 세션에 마운트 가능한 폴더 목록을 확인할 수 있습니다. 폴더 이름을 클릭해 파일 탐색기를 사용할 수 있습니다. 파일 "
 "탐색기에 대한 자세한 설명은  :ref:`폴더 내용 조회하기 <explore_folder>` 섹션을 참고하세요."
 
-#: ../../sessions_all/sessions_all.rst:222
+#: ../../sessions_all/sessions_all.rst:240
 msgid ""
 "New folder can be created by clicking the '+' button next to the search "
 "box. When new folder is created, it will automatically be selected as the"
@@ -434,18 +484,18 @@ msgstr ""
 "폴더로 자동 선택됩니다. 폴더 생성 모달에 대한 자세한 사용 방법은 :ref:`스토리지 폴더 "
 "생성<create_storage_folder>` 를 참고하세요. "
 
-#: ../../sessions_all/sessions_all.rst:231
+#: ../../sessions_all/sessions_all.rst:249
 msgid "Network"
 msgstr "네트워크"
 
-#: ../../sessions_all/sessions_all.rst:233
+#: ../../sessions_all/sessions_all.rst:251
 msgid ""
 "Click the 'Next' button below, or the 'Network' menu on the right to "
 "proceed to the next page. On this page, Network configuration can be done"
 " such as Preopen Ports."
 msgstr "다음 페이지로 진행하려면 아래쪽의 '다음' 버튼을 클릭하거나, 우측의 '네트워크' 버튼을 클릭하세요."
 
-#: ../../sessions_all/sessions_all.rst:236
+#: ../../sessions_all/sessions_all.rst:254
 msgid ""
 "Set Preopen Ports: Provides an interface for users to set preopen ports "
 "in a compute session. Refer to the :ref:`How to add preopen ports before "
@@ -454,11 +504,11 @@ msgstr ""
 "사전 개방 포트: 사용자가 연산 세션에 사전 개방 포트를 설정할 수 있는 인터페이스를 제공합니다. 사용 방법은 :ref:`세션 "
 "생성하기 전에 사전 개방 포트를 추가하는 방법<set_preopen_ports>` 섹션을 참고하십시오."
 
-#: ../../sessions_all/sessions_all.rst:247
+#: ../../sessions_all/sessions_all.rst:265
 msgid "Confirm and Launch"
 msgstr "검토 및 시작"
 
-#: ../../sessions_all/sessions_all.rst:251
+#: ../../sessions_all/sessions_all.rst:269
 msgid ""
 "If you are done with the network setting, click the 'Next' button below, "
 "or 'Confirm and Launch' button on the right to proceed to the last page."
@@ -466,7 +516,7 @@ msgstr ""
 "네트워크 설정을 완료했다면, 아래쪽의 '다음' 버튼을 클릭하거나, 우측의 '검토 및 시작' 버튼을 클릭하여 마지막 페이지로 "
 "이동합니다."
 
-#: ../../sessions_all/sessions_all.rst:254
+#: ../../sessions_all/sessions_all.rst:272
 msgid ""
 "On the last page, users could view information of session(s) to create, "
 "such as environment itself, allocated resources, mount information, "
@@ -480,23 +530,23 @@ msgstr ""
 "있다면 '이전' 버튼을 클릭하여 이전 페이지로 돌아갈 수 있습니다. 혹은, 각 카드 우측 상단에 있는 '수정' 버튼을 눌러 해당 "
 "페이지로 돌아갈 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:264
+#: ../../sessions_all/sessions_all.rst:282
 msgid ""
 "If there is an issue with the settings, an error message will be "
 "displayed as follows. Users can edit their settings when this happens."
 msgstr "설정에 문제가 있는 경우, 다음과 같이 오류가 표시됩니다. 설정을 수정하려면 '수정' 버튼을 클릭하십시오."
 
-#: ../../sessions_all/sessions_all.rst:271
+#: ../../sessions_all/sessions_all.rst:289
 msgid ""
 "When you click the 'Launch' button, a warning dialog appears stating that"
 " there are no mounted folders. If folder mounting is not required, you "
 "can ignore the warning and click the 'Start' button in the dialog to "
 "proceed."
 msgstr ""
-"폴더 마운트 없이 시작 버튼을 클릭하면, 아무 폴더를 마운트하지 않았다는 경고 대화 상자가 나타납니다. 폴더를 마운트할 필요가 "
-"없는 경우, 경고 대화 상자의 '시작' 버튼을 클릭하여 세션을 생성합니다. "
+"폴더 마운트 없이 시작 버튼을 클릭하면, 아무 폴더를 마운트하지 않았다는 경고 대화 상자가 나타납니다. 폴더를 마운트할 필요가 없는"
+" 경우, 경고 대화 상자의 '시작' 버튼을 클릭하여 세션을 생성합니다. "
 
-#: ../../sessions_all/sessions_all.rst:278
+#: ../../sessions_all/sessions_all.rst:296
 msgid ""
 "When a new compute session is added in the **Running** tab, a "
 "notification appears at the bottom-right corner of the screen. The "
@@ -507,21 +557,20 @@ msgid ""
 " **Notifications** in the header."
 msgstr ""
 "새로운 연산 세션이 **실행 중** 탭에 추가되면, 화면 우측 하단에 알림이 나타납니다. 알림의 좌측 하단 영역에는 세션 상태가 "
-"표시되고, 우측 하단 영역에는 앱 대화 상자 열기, 터미널 실행, 컨테이너 로그 보기, 세션 종료 버튼이 포함되어 있습니다. 헤더의 "
-"**알림** 을 클릭하여 이 세션 생성 알림을 다시 볼 수도 있습니다."
+"표시되고, 우측 하단 영역에는 앱 대화 상자 열기, 터미널 실행, 컨테이너 로그 보기, 세션 종료 버튼이 포함되어 있습니다. 헤더의"
+" **알림** 을 클릭하여 이 세션 생성 알림을 다시 볼 수도 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:292
+#: ../../sessions_all/sessions_all.rst:310
 msgid ""
 "By clicking the app dialog button on the far left, you can view the "
 "available app services."
-msgstr ""
-"가장 왼쪽에 있는 앱 대화 상자 버튼을 클릭하면, 사용 가능한 앱 서비스를 확인할 수 있습니다."
+msgstr "가장 왼쪽에 있는 앱 대화 상자 버튼을 클릭하면, 사용 가능한 앱 서비스를 확인할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:300
+#: ../../sessions_all/sessions_all.rst:318
 msgid "Recent History"
 msgstr "최근 기록"
 
-#: ../../sessions_all/sessions_all.rst:304
+#: ../../sessions_all/sessions_all.rst:322
 msgid ""
 "'Session Launcher' page provides a set of options for creating sessions. "
 "As of 24.09, ``Recent History`` feature has been added to remember "
@@ -530,17 +579,17 @@ msgstr ""
 "Backend.AI 24.09 버전 이후로 세션런처 페이지 우측 상단에 최근 생성된 세션 정보를 확인할 수 있는 ``최근 기록`` "
 "기능이 추가되었습니다. "
 
-#: ../../sessions_all/sessions_all.rst:315
+#: ../../sessions_all/sessions_all.rst:333
 msgid ""
 "The ``Recent History`` modal stores information about the five most "
 "recently created sessions. Clicking a session name takes you to the "
 "'Confirm and Launch' page, which is the final step of session creation. "
 "Each item can be renamed or pinned for easier access."
 msgstr ""
-"``최근 기록`` 모달에는 최근에 생성된 다섯 개의 세션 정보가 저장됩니다. 세션 이름을 클릭하면 세션 생성의 마지막 단계인 "
-"'검토 및 시작' 페이지로 이동합니다. 각 항목은 이름을 변경하거나 고정하여 더 쉽게 접근할 수 있습니다."
+"``최근 기록`` 모달에는 최근에 생성된 다섯 개의 세션 정보가 저장됩니다. 세션 이름을 클릭하면 세션 생성의 마지막 단계인 '검토"
+" 및 시작' 페이지로 이동합니다. 각 항목은 이름을 변경하거나 고정하여 더 쉽게 접근할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:320
+#: ../../sessions_all/sessions_all.rst:338
 msgid ""
 "Superadmins can query all compute session information currently running "
 "(or terminated) in the cluster, and users can only view the sessions they"
@@ -549,7 +598,7 @@ msgstr ""
 "수퍼어드민의 경우 현재 클러스터에서 실행 중인 (또는 종료된) 모든 세션 정보를 확인할 수 있고, 일반 사용자의 경우에는 자신이 "
 "사용한 세션만 조회 가능합니다."
 
-#: ../../sessions_all/sessions_all.rst:325
+#: ../../sessions_all/sessions_all.rst:343
 msgid ""
 "Compute session list may not be displayed normally due to intermittent "
 "network connection problems, and etc. This can be solved by refreshing "
@@ -558,11 +607,11 @@ msgstr ""
 "간헐적인 네트워크 접속 불량 등의 문제로 세션 리스트가 정상적으로 표시되지 않는 경우가 발생할 수 있습니다. 이 때는 브라우저 "
 "페이지를 새로고침하면 해결할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:330
+#: ../../sessions_all/sessions_all.rst:348
 msgid "Session Detail Panel"
 msgstr "세션 상세 정보 패널"
 
-#: ../../sessions_all/sessions_all.rst:332
+#: ../../sessions_all/sessions_all.rst:350
 msgid ""
 "For detailed information on the session, click the session name in the "
 "session list. The session details panel shows the information of the "
@@ -571,47 +620,46 @@ msgid ""
 "agent, cluster mode, resource usage including network I/O, and kernel "
 "information."
 msgstr ""
-"세션에 대한 상세 정보를 확인하려면, 세션 리스트의 세션명을 클릭하십시오. 세션 상세 정보 패널에는 세션 ID, 사용자 ID, 상태, "
-"타입, 실행 환경, 마운트 정보, 자원 할당량, 예약된 시간, 경과 시간, 에이전트, 클러스터 모드, 네트워크 I/O 를 포함한 자원 사용량, "
-"커널 정보 등이 표시됩니다."
+"세션에 대한 상세 정보를 확인하려면, 세션 리스트의 세션명을 클릭하십시오. 세션 상세 정보 패널에는 세션 ID, 사용자 ID, "
+"상태, 타입, 실행 환경, 마운트 정보, 자원 할당량, 예약된 시간, 경과 시간, 에이전트, 클러스터 모드, 네트워크 I/O 를 "
+"포함한 자원 사용량, 커널 정보 등이 표시됩니다."
 
-#: ../../sessions_all/sessions_all.rst:337
+#: ../../sessions_all/sessions_all.rst:355
 msgid ""
 "Click the 'Log' button next to the 'Hostname' in 'Kernels' to view the "
 "logs of that kernel directly."
-msgstr ""
-"'커널' 섹션의 '호스트명' 옆에 있는 '로그' 버튼을 클릭하면 해당 커널의 로그를 직접 확인할 수 있습니다."
+msgstr "'커널' 섹션의 '호스트명' 옆에 있는 '로그' 버튼을 클릭하면 해당 커널의 로그를 직접 확인할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:343
+#: ../../sessions_all/sessions_all.rst:361
 msgid ""
 "Backend.AI provides additional information for sessions in ``PENDING``, "
 "``TERMINATED``, or ``CANCELLED`` states. Click the 'Info' button to check"
 " the details when available."
 msgstr ""
-"Backend.AI 는 ``PENDING``, ``TERMINATED``, 또는 ``CANCELLED`` 상태의 세션에 대해 추가 정보를 제공합니다. "
-"'정보' 버튼을 클릭하여 세부 사항을 확인하십시오."
+"Backend.AI 는 ``PENDING``, ``TERMINATED``, 또는 ``CANCELLED`` 상태의 세션에 대해 추가 "
+"정보를 제공합니다. '정보' 버튼을 클릭하여 세부 사항을 확인하십시오."
 
-#: ../../sessions_all/sessions_all.rst:351
+#: ../../sessions_all/sessions_all.rst:369
 msgid "Use Jupyter Notebook"
 msgstr "Jupyter Notebook 사용하기"
 
-#: ../../sessions_all/sessions_all.rst:353
+#: ../../sessions_all/sessions_all.rst:371
 msgid ""
 "Let’s look at how to use and manage an already running compute session. "
 "Click the first icon in the upper-right corner of the session detail "
 "panel to open the app launcher, which shows the app services available "
 "for that session."
 msgstr ""
-"이미 실행 중인 연산 세션을 어떻게 사용하고 관리하는지 살펴봅시다. 세션 상세 정보 패널 우측 상단의 첫 번째 아이콘을 클릭하여 "
-"앱 런처를 열면 해당 세션에서 사용할 수 있는 앱 서비스가 표시됩니다."
+"이미 실행 중인 연산 세션을 어떻게 사용하고 관리하는지 살펴봅시다. 세션 상세 정보 패널 우측 상단의 첫 번째 아이콘을 클릭하여 앱"
+" 런처를 열면 해당 세션에서 사용할 수 있는 앱 서비스가 표시됩니다."
 
-#: ../../sessions_all/sessions_all.rst:364
+#: ../../sessions_all/sessions_all.rst:382
 msgid ""
 "There are two check options under the app icons. Opening the app with "
 "each item checked applies the following features, respectively:"
 msgstr "앱 아이콘 아래에는 두 가지 체크 옵션이 있습니다. 각 항목을 체크하고 앱을 띄우면 다음과 같은 기능이 반영됩니다:"
 
-#: ../../sessions_all/sessions_all.rst:367
+#: ../../sessions_all/sessions_all.rst:385
 msgid ""
 "Open app to public: Open the app to the public. Basically, web services "
 "such as Terminal and Jupyter Notebook services are not accessible by "
@@ -625,7 +673,7 @@ msgstr ""
 "인증을 거치므로 서비스 URL을 알고 있더라도 다른 사용자가 액세스 할 수 없습니다. 그러나 이 옵션을 선택하면 서비스 URL(및 "
 "포트 번호)을 아는 사람이 접근하고 사용할 수 있습니다. 물론 사용자가 서비스에 접근하려면 네트워크 경로가 있어야합니다."
 
-#: ../../sessions_all/sessions_all.rst:373
+#: ../../sessions_all/sessions_all.rst:391
 msgid ""
 "Try preferred port: Without this option checked, a port number for the "
 "web service is randomly assigned from the port pool prepared in advance "
@@ -640,15 +688,15 @@ msgstr ""
 "않거나 다른 서비스가 이미 포트를 사용 중일 수 있기 때문에 원하는 포트가 항상 할당된다는 보장은 없습니다. 이 경우 포트 번호는 "
 "임의로 할당됩니다."
 
-#: ../../sessions_all/sessions_all.rst:381
+#: ../../sessions_all/sessions_all.rst:399
 msgid "Depending on the system configuration, these options may not be shown."
 msgstr "시스템 설정에 따라, 이 옵션들은 보이지 않을 수도 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:383
+#: ../../sessions_all/sessions_all.rst:401
 msgid "Let's click on Jupyter Notebook."
 msgstr "Jupyter Notebook 을 클릭해봅시다."
 
-#: ../../sessions_all/sessions_all.rst:387
+#: ../../sessions_all/sessions_all.rst:405
 msgid ""
 "Pop up windows will show that Jupyter Notebook is running. This notebook "
 "was created inside a running compute session and can be used easily with "
@@ -663,7 +711,7 @@ msgstr ""
 "제공하는 언어 환경 및 라이브러리를 그대로 활용할 수 있어 별도의 패키지 설치 과정이 필요 없습니다. 자세한 Jupyter "
 "Notebook 사용 법은 공식 문서 등을 참고하시기 바랍니다."
 
-#: ../../sessions_all/sessions_all.rst:394
+#: ../../sessions_all/sessions_all.rst:412
 msgid ""
 "``id_container file`` in the notebook's file explorer, contains a private"
 " SSH key. If necessary, users can download it and use it for SSH / SFTP "
@@ -672,7 +720,7 @@ msgstr ""
 "Notebook 의 파일 탐색기에서 ``id_container`` 파일은 private SSH key 를 담고 있습니다. 필요할 "
 "경우 다운로드 하여 컨테이너로의 SSH/SFTP 접속에 이용할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:398
+#: ../../sessions_all/sessions_all.rst:416
 msgid ""
 "Click the 'NEW' button at the top right and select the Notebook for "
 "Backend.AI, then the ipynb window appears where users can enter their own"
@@ -681,7 +729,7 @@ msgstr ""
 "우측 상단의 NEW 버튼을 클릭한 후 Backend.AI 용 Notebook 을 선택하면 새로운 코드를 입력할 수 있는 ipynb "
 "창이 뜹니다."
 
-#: ../../sessions_all/sessions_all.rst:405
+#: ../../sessions_all/sessions_all.rst:423
 msgid ""
 "In this window, users can enter and execute any code that they want by "
 "using the environment that session provides. The code is executed on one "
@@ -692,7 +740,7 @@ msgstr ""
 "이 창에서 세션 환경에 맞는 코드를 입력하고 실행해볼 수 있습니다. 코드는 Backend.AI 서버를 구성하는 노드 중 연산 세션이"
 " 실제로 생성된 노드에서 실행이 되며, 로컬 머신에는 별도 환경을 구성할 필요가 없습니다."
 
-#: ../../sessions_all/sessions_all.rst:412
+#: ../../sessions_all/sessions_all.rst:430
 msgid ""
 "When window is closed, ``Untitled.ipynb`` file can be founded in the "
 "notebook file explorer. Note that the files created here are deleted when"
@@ -703,11 +751,11 @@ msgstr ""
 "있습니다. 여기 생성된 파일은 세션을 삭제할 경우 같이 삭제되는 것에 주의하십시오. 생성된 파일을 세션이 사라지더라도 보존하는 "
 "방법은 폴더 섹션에서 설명합니다."
 
-#: ../../sessions_all/sessions_all.rst:420
+#: ../../sessions_all/sessions_all.rst:438
 msgid "Use web terminal"
 msgstr "웹 터미널 활용"
 
-#: ../../sessions_all/sessions_all.rst:422
+#: ../../sessions_all/sessions_all.rst:440
 msgid ""
 "This section will explain how to use the web terminal. Click the terminal"
 " icon(second button) to use the container's ttyd app. A terminal will "
@@ -718,13 +766,12 @@ msgid ""
 " with the ``ls`` command. This shows that both apps are running in the "
 "same container environment."
 msgstr ""
-"이번에는 웹 터미널을 활용하는 방법을 설명합니다. 터미널 아이콘(두 번째 버튼)을 클릭하면 컨테이너의 ttyd 앱이 "
-"실행됩니다. 새로운 창에 터미널이 나타나고, 셸 명령어를 실행하여 연산 세션에 접근할 수 있습니다. 명령어에 익숙하다면 "
-"다양한 Linux 명령을 쉽게 실행할 수 있습니다. Jupyter Notebook에서 자동으로 생성 된 "
-"``Untitled.ipynb`` 파일이 ``ls`` 명령어로 조회되는 것을 확인할 수 있습니다. 이는 두 앱이 동일한 컨테이너 환경에서 "
-"실행되고 있음을 보여 줍니다."
+"이번에는 웹 터미널을 활용하는 방법을 설명합니다. 터미널 아이콘(두 번째 버튼)을 클릭하면 컨테이너의 ttyd 앱이 실행됩니다. "
+"새로운 창에 터미널이 나타나고, 셸 명령어를 실행하여 연산 세션에 접근할 수 있습니다. 명령어에 익숙하다면 다양한 Linux 명령을"
+" 쉽게 실행할 수 있습니다. Jupyter Notebook에서 자동으로 생성 된 ``Untitled.ipynb`` 파일이 "
+"``ls`` 명령어로 조회되는 것을 확인할 수 있습니다. 이는 두 앱이 동일한 컨테이너 환경에서 실행되고 있음을 보여 줍니다."
 
-#: ../../sessions_all/sessions_all.rst:431
+#: ../../sessions_all/sessions_all.rst:449
 msgid ""
 "Files created here can also be immediately seen in the Jupyter Notebook "
 "as well. Conversely, changes made to files in Jupyter Notebook can also "
@@ -735,7 +782,7 @@ msgstr ""
 "Jupyter Notebook 에서 편집한 파일의 변경 사항도 터미널에서 바로 확인할 수 있습니다. 같은 연산 세션을 사용하고 있기"
 " 때문입니다."
 
-#: ../../sessions_all/sessions_all.rst:434
+#: ../../sessions_all/sessions_all.rst:452
 msgid ""
 "In addition to this, users can use web-based services such as "
 "TensorBoard, Jupyter Lab, etc., depending on the type of environments "
@@ -744,34 +791,34 @@ msgstr ""
 "이 외에도 연산 세션이 제공하는 서비스의 종류에 따라 TensorBoard, Jupyter Lab 등과 같은 웹 기반 서비스를 "
 "이용할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:439
+#: ../../sessions_all/sessions_all.rst:457
 msgid "Query compute session log"
 msgstr "연산 세션 로그 조회"
 
-#: ../../sessions_all/sessions_all.rst:441
+#: ../../sessions_all/sessions_all.rst:459
 msgid ""
 "Users can view the log of the compute session by clicking the last icon "
 "in the Control panel of the running compute session."
 msgstr "돌아가고 있는 연산 세션의 Control 열의 마지막 아이콘을 클릭하면 연산 세션의 로그를 조회할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:447
+#: ../../sessions_all/sessions_all.rst:465
 msgid "Rename running session"
 msgstr "실행중인 세션 이름 변경하기"
 
-#: ../../sessions_all/sessions_all.rst:449
+#: ../../sessions_all/sessions_all.rst:467
 msgid ""
 "Name of the active session can be changed. Click the 'Edit' button in the"
 " session detail panel to change the session name. New session name should"
 " also follow the :ref:`the authoring rule<session-naming-rule>`."
 msgstr ""
-"실행 중인 세션의 이름을 변경할 수 있습니다. 세션 상세 정보 패널에서 '수정' 버튼을 클릭하여 세션 이름을 변경하십시오. "
-"다만, 새로운 세션 이름도 :ref:`세션 이름 작성 규칙<session-naming-rule>` 은 따라야 합니다."
+"실행 중인 세션의 이름을 변경할 수 있습니다. 세션 상세 정보 패널에서 '수정' 버튼을 클릭하여 세션 이름을 변경하십시오. 다만, "
+"새로운 세션 이름도 :ref:`세션 이름 작성 규칙<session-naming-rule>` 은 따라야 합니다."
 
-#: ../../sessions_all/sessions_all.rst:459
+#: ../../sessions_all/sessions_all.rst:477
 msgid "Delete a compute session"
 msgstr "연산 세션 삭제하기"
 
-#: ../../sessions_all/sessions_all.rst:461
+#: ../../sessions_all/sessions_all.rst:479
 msgid ""
 "To terminate a specific session, simply click on the red power button and"
 " click 'Terminate' button in the dialog. Since the data in the folder "
@@ -779,15 +826,15 @@ msgid ""
 "ends, it is recommended to move the data to the mounted folder or upload "
 "it to the mounted folder from the beginning."
 msgstr ""
-"특정 세션을 종료하려면 빨간색 전원 버튼을 클릭한 후 대화 상자에서 '종료' 버튼을 클릭하십시오. 연산 세션이 종료되면 "
-"연산 세션 내부의 폴더에 있는 데이터가 함께 삭제되므로, 데이터를 마운트된 폴더로 옮기거나 처음부터 마운트된 폴더에 업로드하는 "
-"것을 권장합니다."
+"특정 세션을 종료하려면 빨간색 전원 버튼을 클릭한 후 대화 상자에서 '종료' 버튼을 클릭하십시오. 연산 세션이 종료되면 연산 세션 "
+"내부의 폴더에 있는 데이터가 함께 삭제되므로, 데이터를 마운트된 폴더로 옮기거나 처음부터 마운트된 폴더에 업로드하는 것을 "
+"권장합니다."
 
-#: ../../sessions_all/sessions_all.rst:472
+#: ../../sessions_all/sessions_all.rst:490
 msgid "Idleness checks"
 msgstr "유휴 상태 검사"
 
-#: ../../sessions_all/sessions_all.rst:474
+#: ../../sessions_all/sessions_all.rst:492
 msgid ""
 "Backend.AI supports three types of inactivity (idleness) criteria for "
 "automatic garbage collection of compute sessions: Max Session Lifetime, "
@@ -796,20 +843,20 @@ msgstr ""
 "Backend.AI는 최대 세션 수명 시간, 네트워크 트래픽 기반 유휴 시간, 사용량 기반 자원 수거를 기준으로 세션이 자동으로 "
 "삭제될 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:478
+#: ../../sessions_all/sessions_all.rst:496
 msgid ""
 "The criteria for session termination can be found in the 'Idle Checks' "
 "section of the session detail panel."
 msgstr "세션 종료 기준은 세션 상세 정보 패널의 '유휴 상태 검사' 섹션에서 확인할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:483
+#: ../../sessions_all/sessions_all.rst:501
 msgid ""
 "The meaning of idle checkers are as follows, and more detailed "
 "explanations can be found by clicking the information (i) button in the "
 "idle checks section."
 msgstr "각 항목의 의미는 다음과 같으며, 우측의 정보(i) 버튼을 클릭해서 자세한 설명을 확인할 수도 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:486
+#: ../../sessions_all/sessions_all.rst:504
 msgid ""
 "Max Session Lifetime: Force-terminate sessions after this time from "
 "creation. This measure prevents sessions from running indefinitely."
@@ -817,7 +864,7 @@ msgstr ""
 "최대 세션 수명 시간: 세션 생성 후 이 시간이 지나면 세션을 강제 종료합니다. 이는 세션이 무한히 실행되는 것을 방지하기 위한 "
 "조치입니다."
 
-#: ../../sessions_all/sessions_all.rst:488
+#: ../../sessions_all/sessions_all.rst:506
 msgid ""
 "Network Idle Timeout: Force-terminate sessions that do not exchange data "
 "with the user (browser or web app) after this time. Traffic between the "
@@ -834,7 +881,7 @@ msgstr ""
 "않으면 자동 삭제 조건을 만족하게 됩니다. 연산 세션에서 작업을 수행 중인 프로세스가 있더라도, 사용자와의 상호작용이 없는 경우에는"
 " 삭제 대상입니다."
 
-#: ../../sessions_all/sessions_all.rst:494
+#: ../../sessions_all/sessions_all.rst:512
 msgid ""
 "Utilization Checker: Resources allocated to a compute session are "
 "reclaimed based on the utilization of those resources. The decision to "
@@ -843,7 +890,7 @@ msgstr ""
 "사용량 기반 자원 수거: 연산 세션에 할당된 자원을 자원의 활용률을 기준으로 회수합니다. 연산 세션의 삭제 여부는 다음 두 가지 "
 "요소에 따라 결정됩니다:"
 
-#: ../../sessions_all/sessions_all.rst:498
+#: ../../sessions_all/sessions_all.rst:516
 msgid ""
 "Grace Period: The time during which the utilization idle checker is "
 "inactive. Even with low usage, the compute session won't be terminated "
@@ -859,7 +906,7 @@ msgstr ""
 "자원 사용률이 기준에 미치지 못하는 경우 해당 세션이 삭제될 수 있습니다. 유예 기간은 세션 종료가 이루어지지 않는 것을 보장하는 "
 "시간일 뿐입니다. 이는 주로 사용률이 낮은 GPU 자원을 효율적으로 관리하기 위한 조치입니다."
 
-#: ../../sessions_all/sessions_all.rst:505
+#: ../../sessions_all/sessions_all.rst:523
 #, python-format
 msgid ""
 "Utilization Threshold: If the resource utilization of a compute session "
@@ -874,7 +921,7 @@ msgstr ""
 "자동으로 삭제됩니다. 예를 들어, 가속 장치 사용률 기준을 1%로 설정했다면 idle timeout 시간 동안 평균 가속 장치 "
 "사용률이 1% 미만인 연산 세션은 삭제 대상이 됩니다. 값이 설정되지 않는 자원은 자동 삭제 기준에서 제외됩니다."
 
-#: ../../sessions_all/sessions_all.rst:514
+#: ../../sessions_all/sessions_all.rst:532
 msgid ""
 "After the grace period, sessions can be terminated anytime if utilization"
 " remains low. Briefly using the resources does not extend the grace "
@@ -884,7 +931,7 @@ msgstr ""
 "유예 기간이 지난 후에는 사용량이 낮으면 언제든지 삭제될 수 있습니다. 자원을 잠깐 사용했다고 해서 유예 기간이 연장되지 않습니다."
 " 오직 현 시점으로부터 지난 idle timeout 시간 동안의 평균 자원 사용률만이 고려됩니다."
 
-#: ../../sessions_all/sessions_all.rst:518
+#: ../../sessions_all/sessions_all.rst:536
 msgid ""
 "Hovering the mouse over the Utilization Checker will display a tooltip "
 "with the utilization and threshold values. The text color changes to "
@@ -894,17 +941,17 @@ msgstr ""
 "사용량 기반 자원 수거에 마우스를 가져가면, 사용률과 수거 기준값을 보여주는 툴팁이 나타납니다. 현재 사용률이 수거 기준값에 "
 "접근할수록(사용량이 저조할수록) 글자 색이 노란색, 빨간색 순으로 변하게 됩니다."
 
-#: ../../sessions_all/sessions_all.rst:524
+#: ../../sessions_all/sessions_all.rst:542
 msgid ""
 "Depending on the environment settings, idle checkers and resource types "
 "of utilization checker's tooltip may be different."
 msgstr "환경 설정 값에 따라, 유휴 상태 검사 기준과 사용량 기반 자원 수거 툴팁에 나타나는 자원 항목이 다르게 보일 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:531
+#: ../../sessions_all/sessions_all.rst:549
 msgid "How to add environment variable before creating a session"
 msgstr "세션 생성하기 전에 환경 변수를 추가하는 방법"
 
-#: ../../sessions_all/sessions_all.rst:533
+#: ../../sessions_all/sessions_all.rst:551
 msgid ""
 "To give more convenient workspace for users, Backend.AI supports "
 "environment variable setting in session launching. In this feature, users"
@@ -915,7 +962,7 @@ msgstr ""
 "지원합니다. 이 기능에서 여러분은 ``PATH`` 를 비롯한 모든 환경 변수를 환경변수 설정 다이얼로그에서 환경 변수명과 환경 변수"
 " 값을 입력해서 추가할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:537
+#: ../../sessions_all/sessions_all.rst:555
 msgid ""
 "To add environment variable, simply click '+ Add environment variables' "
 "button of the Variable. Also, you can remove the variable by clicking '-'"
@@ -929,17 +976,17 @@ msgstr ""
 msgid "Env Configuration Button"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:544
+#: ../../sessions_all/sessions_all.rst:562
 msgid ""
 "You can write down variable name and value in the same line of the input "
 "fields."
 msgstr "환경 변수 명과 값을 같은 행의 입력 필드에 입력할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:549
+#: ../../sessions_all/sessions_all.rst:567
 msgid "How to add preopen ports before creating a session"
 msgstr "세션 생성하기 전에 사전 개방 포트를 추가하는 방법"
 
-#: ../../sessions_all/sessions_all.rst:551
+#: ../../sessions_all/sessions_all.rst:569
 msgid ""
 "Backend.AI supports preopen ports setting at container startup. When "
 "using this feature, there is no need to build separate images when you "
@@ -948,7 +995,7 @@ msgstr ""
 "Backend.AI는 컨테이너 시작 전 사전 개방 포트를 설정하는 것을 지원합니다. 이 기능을 사용하면, 서빙 포트를 노출하기 위해"
 " 별도의 이미지를 추가로 빌드할 필요가 없습니다."
 
-#: ../../sessions_all/sessions_all.rst:554
+#: ../../sessions_all/sessions_all.rst:572
 msgid ""
 "To add preopen ports, simply enter multiple values separated by either a "
 "comma (,) or a space."
@@ -958,7 +1005,7 @@ msgstr "사전 개방 포트를 추가하려면 쉼표(,)나 공백으로 구분
 msgid "Preopen Ports Configuration"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:560
+#: ../../sessions_all/sessions_all.rst:578
 msgid ""
 "In the forth page of session creation page, users can add, update and "
 "delete written preopen ports. To see more detail information, please "
@@ -967,7 +1014,7 @@ msgstr ""
 "해당 다이얼로그에서 사전 개방 포트를 추가하거나, 작성한 사전 개방 포트를 갱신, 삭제할 수 있습니다. 더욱 자세한 설명이 필요한 "
 "경우, 다이얼로그 헤더 부분에 있는 '도움말 (?)' 버튼을 클릭해주세요."
 
-#: ../../sessions_all/sessions_all.rst:563
+#: ../../sessions_all/sessions_all.rst:581
 msgid ""
 "Users can put port numbers in between 1024 ~ 65535, to the input fields. "
 "Then, press 'Enter'. Users can specify multiple ports, separated by "
@@ -977,7 +1024,7 @@ msgstr ""
 "입력란에 1024 ~ 65535 사이의 포트값을 입력한 뒤, 엔터 키를 누르세요. 각 포트는 쉼표(,)로 구분되며, 여러 포트를 "
 "설정할 수 있습니다. 설정된 사전 개방 포트값은 세션 앱 런처에서 확인할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:571
+#: ../../sessions_all/sessions_all.rst:589
 msgid ""
 "The preopen ports are **the internal ports within the container**. "
 "Therefore, unlike other apps, when users click the preopen ports in the "
@@ -987,11 +1034,11 @@ msgstr ""
 "사전 개방 포트는 **컨테이너 내부 포트** 입니다. 따라서, 다른 앱들과 달리 세션 앱 런처에서 사전 개방 포트를 클릭하면 빈 "
 "페이지가 나타납니다."
 
-#: ../../sessions_all/sessions_all.rst:577
+#: ../../sessions_all/sessions_all.rst:595
 msgid "Save session commit"
 msgstr "세션 커밋 저장하기"
 
-#: ../../sessions_all/sessions_all.rst:581
+#: ../../sessions_all/sessions_all.rst:599
 msgid ""
 "Backend.AI supports \\\"Convert Session to Image\\\" feature from 24.03. "
 "Committing a ``RUNNING`` session will save the current state of the "
@@ -1002,16 +1049,16 @@ msgid ""
 "and can only contain alphanumeric letters, hyphens (``-``), or "
 "underscores (``_``)."
 msgstr ""
-"Backend.AI는 24.03버전부터 \\“세션을 이미지로 변환\\” 기능을 지원합니다. ``RUNNING`` 상태의 세션을 커밋하면 "
-"현재 세션의 상태를 새로운 이미지로 저장할 수 있습니다. 세션 상세 정보 패널에서 '커밋' 버튼(네 번째 아이콘)을 클릭하면 "
-"세션 정보를 표시하는 다이얼로그가 열립니다. 세션 이름을 입력한 후, 세션을 새로운 이미지로 변환할 수 있습니다. 세션 이름은 "
-"4자에서 32자 사이여야 하며, 영어, 숫자, 하이픈(``-``), 밑줄(``_``)만 포함할 수 있습니다."
+"Backend.AI는 24.03버전부터 \\“세션을 이미지로 변환\\” 기능을 지원합니다. ``RUNNING`` 상태의 세션을 "
+"커밋하면 현재 세션의 상태를 새로운 이미지로 저장할 수 있습니다. 세션 상세 정보 패널에서 '커밋' 버튼(네 번째 아이콘)을 "
+"클릭하면 세션 정보를 표시하는 다이얼로그가 열립니다. 세션 이름을 입력한 후, 세션을 새로운 이미지로 변환할 수 있습니다. 세션 "
+"이름은 4자에서 32자 사이여야 하며, 영어, 숫자, 하이픈(``-``), 밑줄(``_``)만 포함할 수 있습니다."
 
 #: ../../sessions_all/sessions_all.rst:-1
 msgid "Push session to customized image"
 msgstr "사용자 정의 이미지를 세션으로 푸시"
 
-#: ../../sessions_all/sessions_all.rst:592
+#: ../../sessions_all/sessions_all.rst:610
 msgid ""
 "After filling out session name in the input field, click the 'PUSH "
 "SESSION TO CUSTOMIZED IMAGE' button. The customized image created in this"
@@ -1025,7 +1072,7 @@ msgstr ""
 "이미지는 향후 세션 생성에서 사용할 수 있습니다. 그러나 이미지 커밋을 위해 컨테이너에 마운트된 디렉토리는 외부 리소스로 간주되어 "
 "최종 이미지에 포함되지 않습니다. ``/home/work`` 디렉토리가 마운트된 폴더(스크래치 디렉토리)임을 기억해주세요."
 
-#: ../../sessions_all/sessions_all.rst:598
+#: ../../sessions_all/sessions_all.rst:616
 msgid ""
 "Currently, Backend.AI supports \"Convert Session to Image\" only when the"
 " session is in ``INTERACTIVE`` mode. To prevent unexpected error, users "
@@ -1036,7 +1083,7 @@ msgstr ""
 "프로세스 중에 예기치 않은 오류를 방지하기 위해, 세션 종료를 명령하더라도 실제로는 종료되지 않을 수 있습니다. 진행 중인 "
 "프로세스를 중지하려면 세션을 확인하고 강제로 종료하세요."
 
-#: ../../sessions_all/sessions_all.rst:603
+#: ../../sessions_all/sessions_all.rst:621
 msgid ""
 "The number of times to \"Convert Session to Image\" may be limited by the"
 " user resource policy. In this case, :ref:`remove the existing customized"
@@ -1046,11 +1093,11 @@ msgstr ""
 "사용자 자원 정책에 의해 “세션을 이미지로 변환“ 작업 횟수가 제한될 수 있습니다. 이 경우, :ref:`기존 사용자 정의 이미지를"
 " 제거<delete-customized-image>` 한 후 다시 시도하거나 관리자에게 문의하세요."
 
-#: ../../sessions_all/sessions_all.rst:609
+#: ../../sessions_all/sessions_all.rst:627
 msgid "Utilizing converted images of ongoing sessions"
 msgstr "진행 중인 세션의 변환된 이미지 활용"
 
-#: ../../sessions_all/sessions_all.rst:611
+#: ../../sessions_all/sessions_all.rst:629
 msgid ""
 "Converting an ongoing session into an image allows users to select this "
 "image from the environments in the session launcher when creating a new "
@@ -1066,7 +1113,7 @@ msgstr ""
 msgid "Select customized image"
 msgstr "사용자 정의 이미지 선택"
 
-#: ../../sessions_all/sessions_all.rst:620
+#: ../../sessions_all/sessions_all.rst:638
 msgid ""
 "To manually enter the environment name for future session creation, "
 "please click the copy icon."
@@ -1076,11 +1123,11 @@ msgstr "향후 세션 생성을 위해 환경 이름을 수동으로 입력하�
 msgid "Copy customized image"
 msgstr "사용자 정의 이미지 복사"
 
-#: ../../sessions_all/sessions_all.rst:630
+#: ../../sessions_all/sessions_all.rst:648
 msgid "Advanced web terminal usage"
 msgstr "웹 터미널 고급 사용법"
 
-#: ../../sessions_all/sessions_all.rst:632
+#: ../../sessions_all/sessions_all.rst:650
 msgid ""
 "The web-based terminal internally embeds a utility called `tmux "
 "<https://github.com/tmux/tmux/wiki>`_. tmux is a terminal multiplexer "
@@ -1095,15 +1142,15 @@ msgstr ""
 "terminal multiplexer 로, 쉘이 닫히더라도 작업하던 내용을 보존할 수 있는 등 다양한 장점을 가지고 있습니다. 보다"
 " 강력한 터미널 기능을 활용하고 싶다면 tmux 공식 문서 및 기타 인터넷 상의 다양한 사용 예제를 참고하십시오."
 
-#: ../../sessions_all/sessions_all.rst:639
+#: ../../sessions_all/sessions_all.rst:657
 msgid "Here we are introducing some simple but useful features."
 msgstr "여기서는 몇 가지 간단하지만 유용한 기능을 소개하겠습니다."
 
-#: ../../sessions_all/sessions_all.rst:642
+#: ../../sessions_all/sessions_all.rst:660
 msgid "Copy terminal contents"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:644
+#: ../../sessions_all/sessions_all.rst:662
 msgid ""
 "tmux offers a number of useful features, but it's a bit confusing for "
 "first-time users. In particular, tmux has its own clipboard buffer, so "
@@ -1120,7 +1167,7 @@ msgstr ""
 "쉘을 사용하고 있는 상태에서는 마우스 드래그를 통해 터미널 내용을 복사한 후 사용자 컴퓨터의 다른 프로그램에 붙여넣을 수가 "
 "없습니다. 소위 말하는 ``Ctrl-C`` / ``Ctrl-V`` 가 작동하지 않는 것입니다."
 
-#: ../../sessions_all/sessions_all.rst:652
+#: ../../sessions_all/sessions_all.rst:670
 msgid ""
 "If copy and paste of terminal contents is needed to system's clipboard, "
 "users can temporarily turn off tmux's mouse support. First, press "
@@ -1137,7 +1184,7 @@ msgstr ""
 " 그 후 터미널에서 마우스로 원하는 텍스트를 드래그 하고 ``Ctrl-C`` 또는 ``Cmd-C`` 키를 누르면 사용자 컴퓨터의 "
 "클립보드에 해당 내용이 복사 됩니다."
 
-#: ../../sessions_all/sessions_all.rst:660
+#: ../../sessions_all/sessions_all.rst:678
 msgid ""
 "With mouse support turned off, scrolling through the mouse wheel is not "
 "supprted, to see the contents of the previous page from the terminal. In "
@@ -1149,7 +1196,7 @@ msgstr ""
 "켜면 됩니다. ``Ctrl-B`` 를 누른 후 이번에는 ``:set -g mouse on`` 을 입력해 봅시다. 이제 마우스 휠을 "
 "스크롤하여 이전 페이지의 내용을 볼 수 있게 되었습니다."
 
-#: ../../sessions_all/sessions_all.rst:665
+#: ../../sessions_all/sessions_all.rst:683
 msgid ""
 "If you remember ``:set -g mouse off`` or ``:set -g mouse on`` after "
 "``Ctrl-B``, you can use the web terminal more conveniently."
@@ -1157,7 +1204,7 @@ msgstr ""
 "이와 같이 ``Ctrl-B`` 후 ``:set -g mouse off`` 또는 ``:set -g mouse on`` 을 기억하면 "
 "조금 더 편리하게 웹 터미널을 활용할 수 있습니다."
 
-#: ../../sessions_all/sessions_all.rst:669
+#: ../../sessions_all/sessions_all.rst:687
 msgid ""
 "``Ctrl-B`` is tmux's default control mode key. If users set another "
 "control key by modifying ``.tmux.conf`` in user home directory, they "
@@ -1166,23 +1213,23 @@ msgstr ""
 "``Ctrl-B`` 키는 tmux 의 기본 제어 모드 키입니다. 만약 홈 디렉토리의 ``.tmux.conf`` 를 수정하여 다른 "
 "제어 키를 설정한 경우에는, ``Ctrl-B`` 대신 설정된 키 조합을 눌러야 합니다."
 
-#: ../../sessions_all/sessions_all.rst:674
+#: ../../sessions_all/sessions_all.rst:692
 msgid "In the Windows environment, refer to the following shortcuts."
 msgstr "윈도우즈 환경에서는 다음 단축키를 참고하세요."
 
-#: ../../sessions_all/sessions_all.rst:676
+#: ../../sessions_all/sessions_all.rst:694
 msgid "Copy: Hold down ``Shift``, right-click and drag"
 msgstr "복사: ``Shift`` 키를 누른 상태에서 마우스 우클릭해서 드래그"
 
-#: ../../sessions_all/sessions_all.rst:677
+#: ../../sessions_all/sessions_all.rst:695
 msgid "Paste: Press ``Ctrl-Shift-V``"
 msgstr "불여넣기: ``Ctrl-Shift-V`` 키를 누름"
 
-#: ../../sessions_all/sessions_all.rst:680
+#: ../../sessions_all/sessions_all.rst:698
 msgid "Check the terminal history using keyboard"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:682
+#: ../../sessions_all/sessions_all.rst:700
 msgid ""
 "There is also a way to copy the terminal contents and check the previous "
 "contents of the terminal simultaneously. It is to check the previous "
@@ -1196,11 +1243,11 @@ msgstr ""
 " 봅시다. 키보드 만으로 터미널의 이전 내용을 탐색할 수 있다는 것을 확인할 수 있습니다. 탐색 모드에서 빠져 나오려면 ``q`` "
 "키를 눌러주면 됩니다. 이 방법을 이용하면 마우스 지원을 끈 상태에서도 터미널 이전 내용 확인이 가능합니다."
 
-#: ../../sessions_all/sessions_all.rst:690
+#: ../../sessions_all/sessions_all.rst:708
 msgid "Spawn multiple shells"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:692
+#: ../../sessions_all/sessions_all.rst:710
 msgid ""
 "The main advantage of tmux is to launch and use multiple shells in one "
 "terminal window. Pressing ``Ctrl-B`` key and ``c``. will show the new "
@@ -1222,7 +1269,7 @@ msgstr ""
 msgid "tmux's multiple session management"
 msgstr ""
 
-#: ../../sessions_all/sessions_all.rst:704
+#: ../../sessions_all/sessions_all.rst:722
 msgid ""
 "In this way, users can use multiple shell environments within a web "
 "terminal. To exit or terminate the current shell, just enter ``exit`` "
@@ -1231,24 +1278,25 @@ msgstr ""
 "첫 번째 쉘 환경이 나타나는 것을 볼 수 있습니다. 이러한 방식으로 웹 터미널 내에서 여러 쉘 환경을 사용할 수 있습니다. 현재 "
 "쉘을 종료하려면 ``exit`` 명령을 입력하거나 ``Ctrl-B x`` 키를 누른 다음 ``y`` 를 입력하십시오."
 
-#: ../../sessions_all/sessions_all.rst:708
+#: ../../sessions_all/sessions_all.rst:726
 msgid "In summary:"
 msgstr "정리하면 다음과 같습니다:"
 
-#: ../../sessions_all/sessions_all.rst:710
+#: ../../sessions_all/sessions_all.rst:728
 msgid "``Ctrl-B c``: create a new tmux shell"
 msgstr "``Ctrl-B c``: 새로운 tmux 쉘 생성"
 
-#: ../../sessions_all/sessions_all.rst:711
+#: ../../sessions_all/sessions_all.rst:729
 msgid "``Ctrl-B w``: query current tmux shells and move around among them"
 msgstr "``Ctrl-B w``: tmux 쉘 조회 및 이동/선택"
 
-#: ../../sessions_all/sessions_all.rst:712
+#: ../../sessions_all/sessions_all.rst:730
 msgid "``exit`` or ``Ctrl-B x``: terminate the current shell"
 msgstr "``exit`` 또는 ``Ctrl-B x``: 현재 tmux 쉘 종료"
 
-#: ../../sessions_all/sessions_all.rst:714
+#: ../../sessions_all/sessions_all.rst:732
 msgid ""
 "Combining the above commands allows users to perform various tasks "
 "simultaneously on multiple shells."
 msgstr "위 명령을 조합하여 여러 개의 쉘에서 동시에 다양한 작업을 수행할 수 있습니다."
+

--- a/docs/sessions_all/sessions_all.rst
+++ b/docs/sessions_all/sessions_all.rst
@@ -31,7 +31,9 @@ If needed, setting the name of the session (optional) is also available.
 .. _session-naming-rule:
 
 * Session type: Determines the type of the session. Backend.AI supports four
-  session types: Interactive, Batch, Inference, and System.
+  session types: Interactive, Batch, Inference, and System. Users can select
+  from Interactive, Batch, and Inference types, while System sessions are
+  managed automatically by the platform.
   The following are the primary distinctions between each type:
 
   - Interactive compute session

--- a/docs/sessions_all/sessions_all.rst
+++ b/docs/sessions_all/sessions_all.rst
@@ -2,7 +2,7 @@
 Compute Sessions
 ================
 
-The most visited pages in the Backend.AI WebUI would be the 'Sessions' and 'Data' pages. 
+The most visited pages in the Backend.AI WebUI would be the 'Sessions' and 'Data' pages.
 This document will cover how to query and create container-based compute sessions and utilize various web applications on the 'Sessions' page.
 
 Start a new session
@@ -25,13 +25,14 @@ Click the 'START' button to start a new compute session.
 Session Type
 ^^^^^^^^^^^^
 
-In the first page, users can select the type of session, 'interactive' or 'batch'. 
-If needed, setting the name of the session (optional) is also available. 
+In the first page, users can select the type of session.
+If needed, setting the name of the session (optional) is also available.
 
 .. _session-naming-rule:
 
-* Session type: Determines the type of the session. There are two different types of session, \"Interactive\" and \"Batch\". 
-  The following are the primary distinctions between the two types:
+* Session type: Determines the type of the session. Backend.AI supports four
+  session types: Interactive, Batch, Inference, and System.
+  The following are the primary distinctions between each type:
 
   - Interactive compute session
 
@@ -49,11 +50,11 @@ If needed, setting the name of the session (optional) is also available.
     - Pre-define the script that will be executed when a compute session is
       ready.
     - This session will execute the script as soon as the compute session is ready, and then
-      automatically terminates the session as soon as the execution finishes. 
-      It will utilize the server farm's resources efficiently and flexibly if a user can write the execution script in advance or is 
+      automatically terminates the session as soon as the execution finishes.
+      It will utilize the server farm's resources efficiently and flexibly if a user can write the execution script in advance or is
       building a pipeline of workloads.
-    - Users can set the start time of a batch-type compute session. 
-      However, keep in mind that this feature does not guarantee that the session will start at the registered time. 
+    - Users can set the start time of a batch-type compute session.
+      However, keep in mind that this feature does not guarantee that the session will start at the registered time.
       It may still stay at 'PENDING' due to the lack of resources, etc. Rather, it guarantees that
       the session WILL NOT run until the start time.
     - Users can also set the 'Timeout Duration' of a batch-type compute session.
@@ -63,22 +64,39 @@ If needed, setting the name of the session (optional) is also available.
        :width: 800
        :align: center
 
+  - Inference session
+
+    - Inference sessions are designed for model serving and production AI deployments.
+    - Unlike interactive sessions, inference sessions provide automatic recovery if
+      terminated unexpectedly, enabling disaster recovery for production services.
+    - Features persistent endpoint URLs, auto-scaling, and health checks for
+      reliable model serving infrastructure.
+    - Requires a model definition file for configuration. See
+      :ref:`Model Serving <model-serving>` section for details.
+
+  - System session
+
+    - System sessions are used internally for infrastructure operations such as
+      sFTP file uploads.
+    - These sessions are not created directly by users; they are managed
+      automatically by the system.
+
 * Session name: Users can specify the name of the compute session to be
-  created. If set, this name appears in Session Info, so it is 
+  created. If set, this name appears in Session Info, so it is
   distinguishable among multiple compute sessions. If not specified, random
   word will be assigned automatically. Session names only accept alphanumeric
   characters between 4 and 64 without spaces.
 
-If users create a session with the ``super admin`` or ``admin`` account, 
-they can additionally assign a session owner. If you enable the toggle, 
-a user email field will appear. 
+If users create a session with the ``super admin`` or ``admin`` account,
+they can additionally assign a session owner. If you enable the toggle,
+a user email field will appear.
 
    .. image:: admin_launch_session_owner.png
       :align: center
 
-Enter the email of the user you want to assign the session to, 
-click the 'search' button, and the user's access key will be automatically registered. 
-You can also select a project and resource group. 
+Enter the email of the user you want to assign the session to,
+click the 'search' button, and the user's access key will be automatically registered.
+You can also select a project and resource group.
 
    .. image:: admin_launch_session_owner_project.png
       :align: center
@@ -104,11 +122,11 @@ Environments
 
 For detailed explanations of each item that can be set on the second page, please
 refer to the following:
-     
+
 * Environments: Users can select the base environment for compute sessions such as
-  TensorFlow, PyTorch, C++, etc. The compute session will automatically included into the base environment library. 
+  TensorFlow, PyTorch, C++, etc. The compute session will automatically included into the base environment library.
   If users choose another environment, the corresponding packages will be installed by default.
-* Version: Users can specify the version of the environment. 
+* Version: Users can specify the version of the environment.
   There are multiple versions in a single environment. For example, TensorFlow has multiple versions such as 1.15, 2.3, etc.,
 * Image Name: Users can specify the name of the image to be used for the
   compute session. This configuration may not be available depending on the environment settings.
@@ -141,16 +159,16 @@ Resource allocation
   .. image:: launch_session_resource.png
      :align: center
 
-  The meaning of each item is as follows. 
-  Clicking the 'Help (?)' button will also give more information. 
-  
+  The meaning of each item is as follows.
+  Clicking the 'Help (?)' button will also give more information.
+
   * CPU: The CPU performs basic arithmetic, logic, controlling, and input/output
     (I/O) operations specified by the instructions. In general, more CPUs are beneficial for high-performance computing workloads.
     But, to reflect the advantage of more CPUs, program code must be written to adapt multiple CPUs.
   * Memory: Computer memory is a temporary storage area. It holds the data and
     instructions that the Central Processing Unit (CPU) needs. When using a GPU in
     a machine learning workload, at least twice the memory of the
-    GPU to memory need to be allocated. Otherwise, GPU's idle time will increase, resulting 
+    GPU to memory need to be allocated. Otherwise, GPU's idle time will increase, resulting
     penalty in a performance.
   * Shared Memory: The amount of shared memory in GB to allocate for the compute
     session. Shared memory will use some part of the memory set in RAM. Therefore,
@@ -170,17 +188,17 @@ Resource allocation
      :align: center
 
   * Select Agent: Select the agent to be assigned. By default, the agent is automatically selected
-    by the scheduler. The agent selector displays the actual amount of available resources for each agent. 
+    by the scheduler. The agent selector displays the actual amount of available resources for each agent.
     Currently, this feature is only supported in single-node, single-container environments.
   * Cluster mode: Cluster mode allows users to create
-    multiple compute sessions at once. For more information, refer to the 
+    multiple compute sessions at once. For more information, refer to the
     :ref:`Overview of Backend.AI cluster compute session<backendai-cluster-compute-session>`.
 
   .. note::
      The Agent Select feature may not be available depending on the server environment.
-  
+
 * High-Performance Computing Optimizations: Backend.AI provides configuring values
-  related to HPC Optimizations. 
+  related to HPC Optimizations.
 
   Backend.AI provides configuration UI for internal control variable in ``nthreads-var``.
   Backend.AI sets this value equal to the number of session's CPU cores by default,
@@ -201,18 +219,18 @@ Data & Storage
 
 Click the 'Next' button below, or the 'Data & Storage' menu on the right to proceed to the next page.
 
-When a compute session is destroyed, data deletion is set to default. 
+When a compute session is destroyed, data deletion is set to default.
 However, data stored in the mounted folders will survive.
-Data in those folders can also be reused by mounting it when creating another compute session. 
+Data in those folders can also be reused by mounting it when creating another compute session.
 For further information on how to mount a folder and run a compute session, refer to
-:ref:`Mounting Folders to a Compute Session<session-mounts>`. 
+:ref:`Mounting Folders to a Compute Session<session-mounts>`.
 
 .. image:: launch_session_data.png
    :width: 850
    :align: center
 
-users can specify the data folders to mount in the compute session. 
-Folder explorer can be used by clicking folder name. For further information, 
+users can specify the data folders to mount in the compute session.
+Folder explorer can be used by clicking folder name. For further information,
 please refer :ref:`Explore Folder<explore_folder>` section.
 
 .. image:: folder_explorer.png
@@ -220,12 +238,12 @@ please refer :ref:`Explore Folder<explore_folder>` section.
    :align: center
 
 New folder can be created by clicking the '+' button next to the search box.
-When new folder is created, it will automatically be selected as the folder to mount. 
+When new folder is created, it will automatically be selected as the folder to mount.
 For further information, please refer :ref:`Create Storage Folder<create_storage_folder>` section.
 
 .. image:: folder_create_modal.png
    :width: 600
-   :align: center 
+   :align: center
 
 Network
 ^^^^^^^
@@ -233,7 +251,7 @@ Network
 Click the 'Next' button below, or the 'Network' menu on the right to proceed to the next page.
 On this page, Network configuration can be done such as Preopen Ports.
 
-* Set Preopen Ports: Provides an interface for users to set preopen ports in a 
+* Set Preopen Ports: Provides an interface for users to set preopen ports in a
   compute session. Refer to the :ref:`How to add preopen ports before session creation
   <set_preopen_ports>` for further information.
 
@@ -248,36 +266,36 @@ Confirm and Launch
 
 .. _confirm_and_launch:
 
-If you are done with the network setting, click the 'Next' button below, or 
+If you are done with the network setting, click the 'Next' button below, or
 'Confirm and Launch' button on the right to proceed to the last page.
 
 On the last page, users could view information of session(s) to create,
 such as environment itself, allocated resources, mount information,
 environment variables set on the previous pages, preopen ports, etc.,
-Review the settings, users could launch the session by clicking 'Launch' button. 
+Review the settings, users could launch the session by clicking 'Launch' button.
 Click the 'Edit' button located at the top right of each card to redirect to relevant page.
 
 .. image:: launch_session_confirm.png
    :width: 850
    :align: center
 
-If there is an issue with the settings, an error message will be displayed as follows. 
+If there is an issue with the settings, an error message will be displayed as follows.
 Users can edit their settings when this happens.
 
 .. image:: launch_session_error_card.png
    :width: 350
    :align: center
 
-When you click the 'Launch' button, a warning dialog appears stating that there are no mounted folders. 
+When you click the 'Launch' button, a warning dialog appears stating that there are no mounted folders.
 If folder mounting is not required, you can ignore the warning and click the 'Start' button in the dialog to proceed.
 
 .. image:: no_folder_notification_dialog.png
    :width: 350
    :align: center
 
-When a new compute session is added in the **Running** tab, a notification appears at the bottom-right corner of the screen.  
+When a new compute session is added in the **Running** tab, a notification appears at the bottom-right corner of the screen.
 The bottom-left area of the notification displays the session status, while the bottom-right area includes buttons for opening the app dialog,
-launching the terminal, viewing container logs, and terminating the session.  
+launching the terminal, viewing container logs, and terminating the session.
 You can also view this session creation notification by clicking **Notifications** in the header.
 
 .. image:: session_created.png
@@ -301,8 +319,8 @@ Recent History
 
 .. _recent-history:
 
-'Session Launcher' page provides a set of options for creating sessions. As of 24.09, 
-``Recent History`` feature has been added to remember information about previously created sessions. 
+'Session Launcher' page provides a set of options for creating sessions. As of 24.09,
+``Recent History`` feature has been added to remember information about previously created sessions.
 
 .. image:: recent_history.png
    :width: 800
@@ -312,8 +330,8 @@ Recent History
    :width: 800
    :align: center
 
-The ``Recent History`` modal stores information about the five most recently created sessions.  
-Clicking a session name takes you to the 'Confirm and Launch' page, which is the final step of session creation.  
+The ``Recent History`` modal stores information about the five most recently created sessions.
+Clicking a session name takes you to the 'Confirm and Launch' page, which is the final step of session creation.
 Each item can be renamed or pinned for easier access.
 
 .. note::
@@ -396,7 +414,7 @@ SSH key. If necessary, users can download it and use it for SSH / SFTP access to
 the container.
 
 Click the 'NEW' button at the top right and select the Notebook for Backend.AI,
-then the ipynb window appears where users can enter their own code. 
+then the ipynb window appears where users can enter their own code.
 
 .. image:: backendai_notebook_menu.png
    :width: 400
@@ -409,7 +427,7 @@ need to configure a separate environment on the local machine.
 
 .. image:: notebook_code_execution.png
 
-When window is closed, ``Untitled.ipynb`` file can be founded in the notebook file explorer. 
+When window is closed, ``Untitled.ipynb`` file can be founded in the notebook file explorer.
 Note that the files created here are deleted when session is terminated. The way to preserve those files even
 after the session is terminated is described in the Data & Storage Folders section.
 
@@ -419,7 +437,7 @@ after the session is terminated is described in the Data & Storage Folders secti
 Use web terminal
 ----------------
 
-This section will explain how to use the web terminal. Click the 
+This section will explain how to use the web terminal. Click the
 terminal icon(second button) to use the container's ttyd app. A terminal will appear in a new window
 and users can run shell commands to access the computational session as shown in the following figure.
 If familiar with the commands, users can easily run various Linux commands. ``Untitled.ipynb`` file
@@ -560,7 +578,7 @@ To add preopen ports, simply enter multiple values separated by either a comma (
 In the forth page of session creation page, users can add, update and delete written preopen ports. To see more detail
 information, please click 'Help (?)'' button.
 
-Users can put port numbers in between 1024 ~ 65535, to the input fields. Then, press 'Enter'. Users can specify multiple ports, separated by commas (,). 
+Users can put port numbers in between 1024 ~ 65535, to the input fields. Then, press 'Enter'. Users can specify multiple ports, separated by commas (,).
 Users can check the configured preopen ports in the session app launcher.
 
 .. image:: session_app_launcher.png
@@ -578,9 +596,9 @@ Save session commit
 
 .. _session-commit:
 
-Backend.AI supports \"Convert Session to Image\" feature from 24.03. Committing a ``RUNNING`` session will save the 
+Backend.AI supports \"Convert Session to Image\" feature from 24.03. Committing a ``RUNNING`` session will save the
 current state of the session as a new image. Click the 'Commit' button (the fourth icon) in the session detail panel
-to open a dialog displaying the session information. After entering the session name, users can convert the session to 
+to open a dialog displaying the session information. After entering the session name, users can convert the session to
 a new image. The session name must be 4 to 32 characters long and can only contain alphanumeric letters, hyphens (``-``),
 or underscores (``_``).
 


### PR DESCRIPTION
## Summary

- Add **Agent Selection Strategy** section to resource group documentation (admin_menu.rst)
  - Explain dispersed vs concentrated strategies with use cases
  - Include example scenario and note about inference replica spreading

- Expand **Session Types** documentation (sessions_all.rst)
  - Add Inference session description (model serving, disaster recovery, auto-scaling)
  - Add System session description (internal infrastructure operations)
  - Update introduction to mention all four session types

## Context

These additions address documentation gaps identified when reviewing support chatbot responses about:
1. Allowed session types in resource groups (interactive, batch, inference, system)
2. Agent selection strategy options (dispersed vs concentrated)

## Changes

| File | Changes |
|------|---------|
| `docs/admin_menu/admin_menu.rst` | +37 lines (new Agent Selection Strategy section) |
| `docs/sessions_all/sessions_all.rst` | +16 lines (Inference & System session descriptions) |